### PR TITLE
[c2][decode]Modify the buffer count of VP9 from 10 to 11

### DIFF
--- a/c2_components/include/mfx_c2_decoder_component.h
+++ b/c2_components/include/mfx_c2_decoder_component.h
@@ -213,6 +213,8 @@ private:
 
     MfxC2ColorAspectsWrapper m_colorAspects;
 
+    std::vector<std::unique_ptr<C2Param>> m_updatingC2Configures;
+
     unsigned int m_uOutputDelay = 8u;
     unsigned int m_uInputDelay = 1u;
 };

--- a/c2_components/src/mfx_c2_decoder_component.cpp
+++ b/c2_components/src/mfx_c2_decoder_component.cpp
@@ -843,15 +843,9 @@ mfxStatus MfxC2DecoderComponent::InitDecoder(std::shared_ptr<C2BlockPool> c2_all
             if (MFX_ERR_NONE == mfx_res) {
                if (m_uOutputDelay < decRequest.NumFrameSuggested) {
                     MFX_DEBUG_TRACE_MSG("More buffer needed for decoder output!");
-                    ALOGW("More buffer needed for decoder output! Actual: %d. Expected: %d, update to %d", 
-                        m_uOutputDelay, decRequest.NumFrameSuggested, decRequest.NumFrameSuggested);\
-
-                    m_uOutputDelay = decRequest.NumFrameSuggested;
-                    m_updatingC2Configures.push_back(C2Param::Copy(C2PortDelayTuning::output((C2Uint32Value)m_uOutputDelay)));
-
-                    m_paramStorage.UpdateValue(C2PortDelayTuning::output::PARAM_TYPE, 
-                        std::make_unique<C2PortDelayTuning::output>(m_uOutputDelay));
-                    //mfx_res = MFX_ERR_MORE_SURFACE;
+                    ALOGE("More buffer needed for decoder output! Actual: %d. Expected: %d", 
+                        m_uOutputDelay, decRequest.NumFrameSuggested);
+                    mfx_res = MFX_ERR_MORE_SURFACE;
                }
             } else {
                 MFX_DEBUG_TRACE_MSG("QueryIOSurf failed");


### PR DESCRIPTION
~~1. If OutputDelay less than sugguseted value from MFX, instead of returning error to C2, update the value.~~
2. Modify the default value of VP9 format from 10 to 11.

Signed-off-by: zhangyichix <yichix.zhang@intel.com>