### PR TITLE
Disable HW codec2.0 plugin if hardware is unavailable

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -50,6 +50,10 @@ mfx_cc_defaults {
         "libhardware_headers" // # It's here due to <hardware/gralloc.h> include. Need to remove when the header will be removed
     ],
 
+    shared_libs: [
+        "libcutils"
+    ],
+
     owner: "intel",
     vendor: true
 }

--- a/c2_store/src/mfx_c2_store.cpp
+++ b/c2_store/src/mfx_c2_store.cpp
@@ -24,6 +24,7 @@
 #include "mfx_debug.h"
 #include "mfx_c2_debug.h"
 #include "mfx_c2_component.h"
+#include <cutils/properties.h>
 
 #include <dlfcn.h>
 #include <fstream>
@@ -70,6 +71,15 @@ c2_status_t MfxC2ComponentStore::createComponent(C2String name, std::shared_ptr<
     MFX_DEBUG_TRACE_FUNC;
 
     c2_status_t result = C2_OK;
+
+    char szVendorIntelVideoCodec[PROPERTY_VALUE_MAX] = {'\0'};
+    if(property_get("vendor.intel.video.codec", szVendorIntelVideoCodec, NULL) > 0 ) {
+        if (strncmp(szVendorIntelVideoCodec, "software", PROPERTY_VALUE_MAX) == 0 ) {
+            ALOGI("Property vendor.intel.video.codec is %s in auto_hal.in and will not load hardware codec plugin", szVendorIntelVideoCodec);
+            return C2_NOT_FOUND;
+        }
+    }
+
     if(component != nullptr) {
 
         auto it = m_componentsRegistry_.find(name);


### PR DESCRIPTION
In case hardware is unavailable, don't load codec2.0 components.

Tracked-On: OAM-100214
Signed-off-by: Chen, Tianmi <tianmi.chen@intel.com>