### PR TITLE
Enable HDR video playback for HEVC Main10 profile

### DIFF
--- a/c2_components/include/mfx_c2_decoder_component.h
+++ b/c2_components/include/mfx_c2_decoder_component.h
@@ -208,8 +208,8 @@ private:
 
     std::list<std::unique_ptr<C2Work>> m_flushedWorks;
 
-    C2StreamHdrStaticInfo::output m_hdrStaticInfo;
-    bool m_bSetHdrSei;
+    std::shared_ptr<C2StreamHdrStaticInfo::output> m_hdrStaticInfo;
+    bool m_bSetHdrStatic;
 
     MfxC2ColorAspectsWrapper m_colorAspects;
 

--- a/c2_utils/include/mfx_msdk_debug.h
+++ b/c2_utils/include/mfx_msdk_debug.h
@@ -151,6 +151,20 @@ MFX_DEBUG_DECLARE_VALUE_DESC_PRINTF(mfxStatus)
     MFX_DEBUG_TRACE_I32(_s.NumExtParam); \
     MFX_DEBUG_TRACE_P(_s.ExtParam); \
 
+#define MFX_DEBUG_TRACE__hdrStaticInfo(_s) \
+    MFX_DEBUG_TRACE_F64(_s->mastering.red.x); \
+    MFX_DEBUG_TRACE_F64(_s->mastering.red.y); \
+    MFX_DEBUG_TRACE_F64(_s->mastering.green.x); \
+    MFX_DEBUG_TRACE_F64(_s->mastering.green.y); \
+    MFX_DEBUG_TRACE_F64(_s->mastering.blue.x); \
+    MFX_DEBUG_TRACE_F64(_s->mastering.blue.y); \
+    MFX_DEBUG_TRACE_F64(_s->mastering.white.x); \
+    MFX_DEBUG_TRACE_F64(_s->mastering.white.y); \
+    MFX_DEBUG_TRACE_F64(_s->maxCll); \
+    MFX_DEBUG_TRACE_F64(_s->maxFall); \
+    MFX_DEBUG_TRACE_F64(_s->mastering.minLuminance); \
+    MFX_DEBUG_TRACE_F64(_s->mastering.maxLuminance); \
+
 #define MFX_DEBUG_TRACE__mfxBitstream(_s) \
     MFX_DEBUG_TRACE_I64(_s.TimeStamp); \
     MFX_DEBUG_TRACE_P(_s.Data); \
@@ -160,6 +174,7 @@ MFX_DEBUG_DECLARE_VALUE_DESC_PRINTF(mfxStatus)
     MFX_DEBUG_TRACE_I32(_s.PicStruct); \
     MFX_DEBUG_TRACE_I32(_s.FrameType); \
     MFX_DEBUG_TRACE_I32(_s.DataFlag);
+
 
 #if MFX_DEBUG == MFX_DEBUG_YES
     #define MFX_DEBUG_TRACE__mfxStatus(_e) printf_mfxStatus(MFX_DEBUG_TRACE_VAR, #_e, _e)

--- a/c2_utils/src/mfx_va_frame_pool_allocator.cpp
+++ b/c2_utils/src/mfx_va_frame_pool_allocator.cpp
@@ -139,6 +139,7 @@ mfxStatus MfxVaFramePoolAllocator::AllocFrames(mfxFrameAllocRequest *request,
             }
             MFX_DEBUG_TRACE_I32(response->NumFrameActual);
             MFX_DEBUG_TRACE_I32(request->NumFrameMin);
+            MFX_DEBUG_TRACE_I32(max_buffers);
 
             if (response->NumFrameActual >= request->NumFrameMin) {
                 response->mids = mids.release();


### PR DESCRIPTION
This change includes,
1. Add 10bit yuv format support for main10 profile clips
2. Parse HDR static meta data from HEVC SEI.

Tracked-On: OAM-100284
Signed-off-by: Chen, Tianmi <tianmi.chen@intel.com>