### PR TITLE
Fix sepolicy issue in userbuild

### DIFF
--- a/c2_store/hardware.intel.media.c2@1.0-service.rc
+++ b/c2_store/hardware.intel.media.c2@1.0-service.rc
@@ -1,7 +1,6 @@
 service hardware-intel-media-c2-hal-1-0 /vendor/bin/hw/hardware.intel.media.c2@1.0-service
     class hal
-    user root
-    group root camera mediadrm drmrpc
+    user mediacodec
+    group camera mediadrm drmrpc
     ioprio rt 4
     writepid /dev/cpuset/foreground/tasks
-    seclabel u:r:su:s0

--- a/c2_store/seccomp_policy/android.hardware.media.c2@1.0-x86.policy
+++ b/c2_store/seccomp_policy/android.hardware.media.c2@1.0-x86.policy
@@ -70,4 +70,7 @@ gettid: 1
 getcwd: 1
 geteuid32: 1
 
+getpgid: 1
+sigkill: 1
+
 @include /system/etc/seccomp_policy/crash_dump.x86.policy

--- a/c2_store/seccomp_policy/android.hardware.media.c2@1.0-x86_64.policy
+++ b/c2_store/seccomp_policy/android.hardware.media.c2@1.0-x86_64.policy
@@ -70,4 +70,7 @@ gettid: 1
 getcwd: 1
 geteuid32: 1
 
+getpgid: 1
+sigkill: 1
+
 @include /system/etc/seccomp_policy/crash_dump.x86_64.policy


### PR DESCRIPTION
This change is to change domain user from root to mediacodec.
Otherwise, we will see below error messages and fail to start
codec2.0 service.

W init : type=1400 audit(0.0:534): avc: denied { transition }
for path="/vendor/bin/hw/hardware.intel.media.c2@1.0-service"
dev="dm-5" ino=101 scontext=u:r:init:s0 tcontext=u:r:su:s0
tclass=process permissive=0

Tracked-On:
Signed-off-by: Chen, Tianmi <tianmi.chen@intel.com>