### PR TITLE
Changes for Codec2 enable & OneVPL integration with CiC-cloud

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -33,7 +33,7 @@ mfx_cc_defaults {
     export_include_dirs: ["include"],
 
     include_dirs: [
-        "hardware/intel/external/minigbm-intel/cros_gralloc", // remove then minigbm gets Android.bp
+        "external/minigbm/cros_gralloc", // remove then minigbm gets Android.bp
         "frameworks/av/media/libstagefright/foundation/include",
         "frameworks/av/media/bufferpool/2.0/include",
         "frameworks/av/media/codec2/sfplugin/utils",

--- a/c2_store/Android.bp
+++ b/c2_store/Android.bp
@@ -51,13 +51,12 @@ cc_binary {
         "android.hardware.media.omx@1.0",
         "libavservices_minijail_vendor",
         "libbinder",
-        "libhidltransport",
-        "libhwbinder",
+        "libhidlbase",
         "libstagefright_omx",
         "libstagefright_xmlparser",
     ],
 
-    vintf_fragments: ["manifest_media_c2_V1_0_default.xml"],
+    //vintf_fragments: ["manifest_media_c2_V1_0_default.xml"],
 
     required: ["android.hardware.media.c2@1.0-vendor.policy"],
 

--- a/c2_utils/include/mfx_c2_defs.h
+++ b/c2_utils/include/mfx_c2_defs.h
@@ -29,10 +29,10 @@
 #define CREATE_MFX_C2_COMPONENT_FUNC_NAME "MfxCreateC2Component"
 
 #define MFX_C2_CONFIG_FILE_NAME "mfx_c2_store.conf"
-#define MFX_C2_CONFIG_FILE_PATH "/vendor/etc"
+#define MFX_C2_CONFIG_FILE_PATH "/system/vendor/etc"
 
 #define MFX_C2_CONFIG_XML_FILE_NAME "media_codecs_intel_c2_video.xml"
-#define MFX_C2_CONFIG_XML_FILE_PATH "/vendor/etc"
+#define MFX_C2_CONFIG_XML_FILE_PATH "/system/vendor/etc"
 
 #define MFX_C2_DUMP_DIR "/data/local/tmp"
 #define MFX_C2_DUMP_OUTPUT_SUB_DIR "c2-output"


### PR DESCRIPTION
- Replaced "libhidltransport" & "libhwbinder" with "libhidlbase".
- Commented "vintf_fragments" as "manifest_media_c2_V1_0_default.xml"
is already added by "android.hardware.media.c2" package.
- Updated file copying path to "/system/vendor/" as "/vendor"
symlink doesn't exist initially with cic-cloud.
- Updated path of "cros_gralloc" package

Tracked-On: OAM-100436
Signed-off-by: neeraj solanki <neeraj.solanki@intel.com>