### PR TITLE
[c2][encode] Support for configuring RequestSyncFrame and SyncFrameInterval

### DIFF
--- a/c2_utils/include/mfx_c2_utils.h
+++ b/c2_utils/include/mfx_c2_utils.h
@@ -124,6 +124,8 @@ bool IsI420(const C2GraphicView &view);
 
 bool IsYV12(const C2GraphicView &view);
 
+void ParseGop(const C2StreamGopTuning &gop, uint32_t &syncInterval, uint32_t &iInterval, uint32_t &maxBframes);
+
 // Gives access to prorected constructors of C2Buffer.
 class C2BufferAccessor : public C2Buffer
 {


### PR DESCRIPTION
case: android.media.cts.VideoCodecTest#testSyncFrameAVCCBR
      android.media.cts.VideoCodecTest#testSyncFrameHEVCCBR
      android.media.cts.VideoCodecTest#testSyncFrameVP9CBR

Support configuring RequestSyncFrame to sync frame instantly
and support configuring SyncFrameInterval to sync frame periodically.

Tracked-On: OAM-101038
Signed-off-by: zhangyichix <yichix.zhang@intel.com>