### PR TITLE
Fix media cts testCodecResetsHEVCWithSurface

### DIFF
--- a/c2_buffers/include/mfx_c2_bitstream_in.h
+++ b/c2_buffers/include/mfx_c2_bitstream_in.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021 Intel Corporation
+// Copyright (c) 2017-2022 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -29,35 +29,18 @@
 class MfxC2BitstreamIn
 {
 public:
-    class FrameView
-    {
-    public:
-        FrameView(std::shared_ptr<IMfxC2FrameConstructor> frame_constructor,
-            std::unique_ptr<C2ReadView>&& read_view):
-                m_frameConstructor(frame_constructor), m_readView(std::move(read_view)) {}
-        ~FrameView() { Release(); }
-
-        c2_status_t Release();
-
-    private:
-        std::shared_ptr<IMfxC2FrameConstructor> m_frameConstructor;
-        std::unique_ptr<C2ReadView> m_readView;
-
-    private:
-        MFX_CLASS_NO_COPY(FrameView)
-    };
-
-public:
     MfxC2BitstreamIn(MfxC2FrameConstructorType fc_type);
     virtual ~MfxC2BitstreamIn();
 
     virtual c2_status_t Reset();
 
+    virtual c2_status_t Unload();
+
     virtual std::shared_ptr<IMfxC2FrameConstructor> GetFrameConstructor() { return m_frameConstructor; }
     // Maps c2 linear block and can leave it in mapped state until
     // frame_view freed or frame_view->Release is called.
     virtual c2_status_t AppendFrame(const C2FrameData& buf_pack, c2_nsecs_t timeout,
-        std::unique_ptr<FrameView>* frame_view);
+        std::unique_ptr<C2ReadView>* view);
 
 protected: // variables
     std::shared_ptr<IMfxC2FrameConstructor> m_frameConstructor;

--- a/c2_buffers/src/mfx_c2_bitstream_in.cpp
+++ b/c2_buffers/src/mfx_c2_bitstream_in.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021 Intel Corporation
+// Copyright (c) 2017-2022 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -57,8 +57,25 @@ c2_status_t MfxC2BitstreamIn::Reset()
     return res;
 }
 
+c2_status_t MfxC2BitstreamIn::Unload()
+{
+    MFX_DEBUG_TRACE_FUNC;
+
+    c2_status_t res = C2_OK;
+
+    do {
+        mfxStatus mfx_res = m_frameConstructor->Unload();
+        res = MfxStatusToC2(mfx_res);
+        if(C2_OK != res) break;
+    } while(false);
+
+    MFX_DEBUG_TRACE__android_c2_status_t(res);
+    return res;
+}
+
+
 c2_status_t MfxC2BitstreamIn::AppendFrame(const C2FrameData& buf_pack, c2_nsecs_t timeout,
-    std::unique_ptr<FrameView>* frame_view)
+    std::unique_ptr<C2ReadView>* frame_view)
 {
     MFX_DEBUG_TRACE_FUNC;
 
@@ -102,22 +119,10 @@ c2_status_t MfxC2BitstreamIn::AppendFrame(const C2FrameData& buf_pack, c2_nsecs_
         res = MfxStatusToC2(mfx_res);
         if(C2_OK != res) break;
 
-        *frame_view = std::make_unique<FrameView>(m_frameConstructor, std::move(read_view));
+        *frame_view = std::move(read_view);
 
     } while(false);
 
     MFX_DEBUG_TRACE__android_c2_status_t(res);
-    return res;
-}
-
-c2_status_t MfxC2BitstreamIn::FrameView::Release()
-{
-    MFX_DEBUG_TRACE_FUNC;
-
-    c2_status_t res = C2_OK;
-    if (m_readView) {
-        res = MfxStatusToC2(m_frameConstructor->Unload());
-        m_readView.reset();
-    }
     return res;
 }

--- a/c2_components/include/mfx_c2_decoder_component.h
+++ b/c2_components/include/mfx_c2_decoder_component.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021 Intel Corporation
+// Copyright (c) 2017-2022 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -210,6 +210,9 @@ private:
     std::atomic<bool> m_bFlushing{false};
 
     std::list<std::unique_ptr<C2Work>> m_flushedWorks;
+
+    std::mutex m_readViewMutex;
+    std::map<decltype(C2WorkOrdinalStruct::timestamp), std::unique_ptr<C2ReadView>> m_readViews;
 
     std::shared_ptr<C2StreamHdrStaticInfo::output> m_hdrStaticInfo;
     bool m_bSetHdrStatic;

--- a/c2_components/src/mfx_c2_decoder_component.cpp
+++ b/c2_components/src/mfx_c2_decoder_component.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021 Intel Corporation
+// Copyright (c) 2017-2022 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -516,6 +516,8 @@ c2_status_t MfxC2DecoderComponent::DoStop(bool abort)
     }
 
     m_c2Allocator = nullptr;
+
+    m_readViews.clear();
 
     FreeDecoder();
 
@@ -1495,6 +1497,7 @@ c2_status_t MfxC2DecoderComponent::AllocateFrame(MfxC2FrameOut* frame_out)
         auto pred_unlocked = [&](const MfxC2FrameOut &item) {
             return !item.GetMfxFrameSurface()->Data.Locked;
         };
+
         {
             std::lock_guard<std::mutex> lock(m_lockedSurfacesMutex);
             m_lockedSurfaces.remove_if(pred_unlocked);
@@ -1611,9 +1614,14 @@ void MfxC2DecoderComponent::DoWork(std::unique_ptr<C2Work>&& work)
     bool flushing = false;
 
     do {
-        std::unique_ptr<MfxC2BitstreamIn::FrameView> bitstream_view;
-        res = m_c2Bitstream->AppendFrame(work->input, TIMEOUT_NS, &bitstream_view);
+        std::unique_ptr<C2ReadView> read_view;
+        res = m_c2Bitstream->AppendFrame(work->input, TIMEOUT_NS, &read_view);
         if (C2_OK != res) break;
+
+        {
+            std::lock_guard<std::mutex> lock(m_readViewMutex);
+            m_readViews.emplace(work->input.ordinal.timestamp, std::move(read_view));
+        }
 
         if (work->input.buffers.size() == 0) break;
 
@@ -1743,7 +1751,7 @@ void MfxC2DecoderComponent::DoWork(std::unique_ptr<C2Work>&& work)
             break;
         }
 
-        res = bitstream_view->Release();
+        res = m_c2Bitstream->Unload();
         if (C2_OK != res) break;
 
     } while(false); // fake loop to have a cleanup point there
@@ -1857,6 +1865,10 @@ void MfxC2DecoderComponent::WaitWork(MfxC2FrameOut&& frame_out, mfxSyncPoint syn
     std::shared_ptr<mfxFrameSurface1> mfx_surface = frame_out.GetMfxFrameSurface();
     MFX_DEBUG_TRACE_I32(mfx_surface->Data.Locked);
     MFX_DEBUG_TRACE_I64(mfx_surface->Data.TimeStamp);
+    MFX_DEBUG_TRACE_I32(mfx_surface->Info.CropW);
+    MFX_DEBUG_TRACE_I32(mfx_surface->Info.CropH);
+    MFX_DEBUG_TRACE_I32(m_mfxVideoParams.mfx.FrameInfo.CropW);
+    MFX_DEBUG_TRACE_I32(m_mfxVideoParams.mfx.FrameInfo.CropH);
 
 #if MFX_DEBUG_DUMP_FRAME == MFX_DEBUG_YES
     static int frameIndex = 0;
@@ -1868,6 +1880,7 @@ void MfxC2DecoderComponent::WaitWork(MfxC2FrameOut&& frame_out, mfxSyncPoint syn
     decltype(C2WorkOrdinalStruct::timestamp) ready_timestamp{mfx_surface->Data.TimeStamp};
 
     std::unique_ptr<C2Work> work;
+    std::unique_ptr<C2ReadView> read_view;
 
     {
         std::lock_guard<std::mutex> lock(m_pendingWorksMutex);
@@ -1879,6 +1892,18 @@ void MfxC2DecoderComponent::WaitWork(MfxC2FrameOut&& frame_out, mfxSyncPoint syn
         if (it != m_pendingWorks.end()) {
             work = std::move(it->second);
             m_pendingWorks.erase(it);
+        }
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(m_readViewMutex);
+
+        auto it = m_readViews.find(ready_timestamp);
+
+        if (it != m_readViews.end()) {
+            read_view = std::move(it->second);
+            read_view.reset();
+            m_readViews.erase(it);
         }
     }
 
@@ -2098,9 +2123,15 @@ c2_status_t MfxC2DecoderComponent::Flush(std::list<std::unique_ptr<C2Work>>* con
         }
         m_pendingWorks.clear();
     }
+
     {
         std::lock_guard<std::mutex> lock(m_lockedSurfacesMutex);
         m_lockedSurfaces.clear();
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(m_readViewMutex);
+        m_readViews.clear();
     }
 
     FreeSurfaces();

--- a/c2_utils/include/mfx_frame_constructor.h
+++ b/c2_utils/include/mfx_frame_constructor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021 Intel Corporation
+// Copyright (c) 2017-2022 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -40,8 +40,9 @@ enum MfxC2BitstreamState
 {
     MfxC2BS_HeaderAwaiting = 0,
     MfxC2BS_HeaderCollecting = 1,
-    MfxC2BS_HeaderObtained = 2,
-    MfxC2BS_Resetting = 3,
+    MfxC2BS_HeaderWaitSei = 2,
+    MfxC2BS_HeaderObtained = 3,
+    MfxC2BS_Resetting = 4,
 };
 
 class IMfxC2FrameConstructor
@@ -173,11 +174,13 @@ protected: // functions
     virtual bool      isSPS(mfxI32 code) { return NAL_UT_AVC_SPS == code; }
     virtual bool      isPPS(mfxI32 code) { return NAL_UT_AVC_PPS == code; }
     virtual bool      isSEI(mfxI32 /*code*/) {return false;}
+    virtual bool      isIDR(mfxI32 code) {return NAL_UT_AVC_SLICE_IDR == code;}
     virtual bool      needWaitSEI(mfxI32 /*code*/) {return false;}
 
 protected: // data
     const static mfxU32 NAL_UT_AVC_SPS = 7;
     const static mfxU32 NAL_UT_AVC_PPS = 8;
+    const static mfxU32 NAL_UT_AVC_SLICE_IDR = 5;
 
     mfxBitstream m_sps;
     mfxBitstream m_pps;
@@ -205,12 +208,15 @@ protected: // functions
     // save current SEI
     virtual mfxStatus SaveSEI(mfxBitstream *pSEI);
     virtual bool   isSEI(mfxI32 code) {return NAL_UT_HEVC_SEI == code;}
+    virtual bool   isIDR(mfxI32 code) {return NAL_UT_HEVC_IDR_W_RADL == code || NAL_UT_HEVC_IDR_N_LP == code;}
     virtual bool   needWaitSEI(mfxI32 code) { return NAL_UT_CODED_SLICEs.end() == std::find(NAL_UT_CODED_SLICEs.begin(), NAL_UT_CODED_SLICEs.end(), code);}
 
 protected: // data
     const static mfxU32 NAL_UT_HEVC_SPS = 33;
     const static mfxU32 NAL_UT_HEVC_PPS = 34;
     const static mfxU32 NAL_UT_HEVC_SEI = 39;
+    const static mfxU32 NAL_UT_HEVC_IDR_W_RADL = 19;
+    const static mfxU32 NAL_UT_HEVC_IDR_N_LP  = 20;
     const static std::vector<mfxU32> NAL_UT_CODED_SLICEs;
 
     std::map<mfxU32, mfxPayload> m_SEIMap;

--- a/c2_utils/src/mfx_defs.cpp
+++ b/c2_utils/src/mfx_defs.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021 Intel Corporation
+// Copyright (c) 2017-2022 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -137,7 +137,9 @@ uint32_t MFXGetSurfaceSize(uint32_t FourCC, uint32_t width, uint32_t height)
     mfxU32 nbytes = 0;
 
     switch (FourCC) {
+#ifdef USE_ONEVPL
         case MFX_FOURCC_I420:
+#endif
         case MFX_FOURCC_NV12:
             nbytes = width * height + (width >> 1) * (height >> 1) + (width >> 1) * (height >> 1);
             break;

--- a/c2_utils/src/mfx_va_frame_pool_allocator.cpp
+++ b/c2_utils/src/mfx_va_frame_pool_allocator.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021 Intel Corporation
+// Copyright (c) 2017-2022 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -64,6 +64,8 @@ mfxStatus MfxVaFramePoolAllocator::AllocFrames(mfxFrameAllocRequest *request,
     MFX_DEBUG_TRACE_I32(opt_buffers);
     MFX_DEBUG_TRACE_I32(request->NumFrameMin);
     MFX_DEBUG_TRACE_I32(request->NumFrameSuggested);
+    MFX_DEBUG_TRACE_I32(request->Info.Width);
+    MFX_DEBUG_TRACE_I32(request->Info.Height);
     MFX_DEBUG_TRACE_I64(m_consumerUsage);
 
     if (request->Type & MFX_MEMTYPE_VIDEO_MEMORY_DECODER_TARGET) {


### PR DESCRIPTION
The root cause is that after decoder reset, video
decoding becomes async. The current bitstream data
is released in the previous decoding thread. Thus no
slice data is avaible and onevpl-gpu failed to copy
slice data.

The solution is to de-correlation between frameconstructor
and frame view. Let frame view is release after onevpl
finished the decoding of current bitstream.

Tracked-On: OAM-101053
Signed-off-by: Chen, Tianmi <tianmi.chen@intel.com>