### PR TITLE
Fixed coloraspect related test cases

### DIFF
--- a/c2_components/src/mfx_c2_decoder_component.cpp
+++ b/c2_components/src/mfx_c2_decoder_component.cpp
@@ -1197,6 +1197,30 @@ void MfxC2DecoderComponent::DoConfig(const std::vector<C2Param*> &params,
                 break;
             }
             case kParamIndexColorAspects: {
+                const C2StreamColorAspectsInfo* settings = static_cast<const C2StreamColorAspectsInfo*>(param);
+                android::ColorAspects ca;
+                MFX_DEBUG_TRACE_U32(settings->range);
+                MFX_DEBUG_TRACE_U32(settings->primaries);
+                MFX_DEBUG_TRACE_U32(settings->transfer);
+                MFX_DEBUG_TRACE_U32(settings->matrix);
+
+                ca.mRange = (android::ColorAspects::Range)settings->range;
+                ca.mTransfer = (android::ColorAspects::Transfer)settings->transfer;
+                ca.mMatrixCoeffs = (android::ColorAspects::MatrixCoeffs)settings->matrix;
+                ca.mPrimaries = (android::ColorAspects::Primaries)settings->primaries;
+
+                mfxExtVideoSignalInfo signal_info;
+                MFX_ZERO_MEMORY(signal_info);
+                signal_info.VideoFullRange = settings->range;
+                signal_info.ColourPrimaries = settings->primaries;
+                signal_info.TransferCharacteristics = settings->transfer;
+                signal_info.MatrixCoefficients = settings->matrix;
+
+                m_colorAspects.UpdateBitstreamColorAspects(signal_info);
+                m_colorAspects.SetFrameworkColorAspects(ca);
+                break;
+            }
+            case kParamIndexDefaultColorAspects: {
                 const C2StreamColorAspectsTuning* settings = static_cast<const C2StreamColorAspectsTuning*>(param);
                 android::ColorAspects ca;
                 MFX_DEBUG_TRACE_U32(settings->range);

--- a/c2_utils/src/mfx_c2_color_aspects_wrapper.cpp
+++ b/c2_utils/src/mfx_c2_color_aspects_wrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021 Intel Corporation
+// Copyright (c) 2018-2022 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -19,6 +19,9 @@
 // SOFTWARE.
 
 #include "mfx_c2_color_aspects_wrapper.h"
+
+#undef MFX_DEBUG_MODULE_NAME
+#define MFX_DEBUG_MODULE_NAME "mfx_c2_color_aspects_wrapper"
 
 MfxC2ColorAspectsWrapper::MfxC2ColorAspectsWrapper()
     : m_bIsColorAspectsChanged(false)


### PR DESCRIPTION
android.media.cts.DecoderTest#testH264ColorAspects
android.media.cts.DecoderTest#testH265ColorAspects
android.media.cts.DecoderTest#testMPEG2ColorAspectsTV

The solution is to add configration for default
color apsects.

Tracked-On: OAM-101056
Signed-off-by: Chen, Tianmi <tianmi.chen@intel.com>