### PR TITLE
Fixed dataspace changed issue after seek

### DIFF
--- a/c2_components/include/mfx_c2_decoder_component.h
+++ b/c2_components/include/mfx_c2_decoder_component.h
@@ -219,6 +219,8 @@ private:
 
     MfxC2ColorAspectsWrapper m_colorAspects;
 
+    std::shared_ptr<C2StreamPixelFormatInfo::output> m_pixelFormat;
+
     std::vector<std::unique_ptr<C2Param>> m_updatingC2Configures;
 
     uint64_t m_consumerUsage;

--- a/c2_utils/src/mfx_c2_utils.cpp
+++ b/c2_utils/src/mfx_c2_utils.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021 Intel Corporation
+// Copyright (c) 2017-2022 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -526,6 +526,9 @@ bool MfxIOPatternToC2MemoryType(bool input, mfxU16 io_pattern, C2MemoryType* mem
 
 int MfxFourCCToGralloc(mfxU32 fourcc, bool using_video_memory)
 {
+    MFX_DEBUG_TRACE_FUNC;
+    MFX_DEBUG_TRACE_U32(fourcc);
+
     switch (fourcc)
     {
         case MFX_FOURCC_NV12:


### PR DESCRIPTION
Root cause is that color aspects and pixel format
are set to the default values after seek.

Tracked-On: OAM-101068
Signed-off-by: Chen, Tianmi <tianmi.chen@intel.com>