### PR TITLE
[c2][encode] Adjust minimum and maximum sizes for encoding

### DIFF
--- a/c2_store/data/media_codecs_intel_c2_video.xml
+++ b/c2_store/data/media_codecs_intel_c2_video.xml
@@ -87,7 +87,7 @@ and updated to vendor media codecs.
     <Encoders>
         <MediaCodec name="c2.intel.avc.encoder" type="video/avc">
             <!-- profiles and levels:  ProfileBaseline : Level41 -->
-            <Limit name="size" min="176x144" max="2048x2048" />
+            <Limit name="size" min="176x144" max="4096x4096" />
             <Limit name="alignment" value="2x2" />
             <Limit name="block-size" value="16x16" />
             <Limit name="block-count" range="1-8192" /> <!-- max 2048x1024 -->
@@ -98,7 +98,7 @@ and updated to vendor media codecs.
             <Diagnostics dumpOutput="false" />
         </MediaCodec>
         <MediaCodec name="c2.intel.hevc.encoder" type="video/hevc" >
-            <Limit name="size" min="64x64" max="3840x2160" />
+            <Limit name="size" min="176x144" max="8192x8192" />
             <Limit name="alignment" value="2x2" />
             <Limit name="block-size" value="16x16" />
             <Limit name="blocks-per-second" range="1-972000" />


### PR DESCRIPTION
case: android.media.cts.VideoEncoderTest#testOtherH265FlexMaxMin
      android.media.cts.VideoEncoderTest#testOtherH265FlexMinMax
      android.media.cts.VideoEncoderTest#testOtherH265FlexMinMin

Incorrect size will cause the driver to return an error.

Tracked-On: OAM-101096
Signed-off-by: zhangyichix <yichix.zhang@intel.com>