### PR TITLE
Fixed testHEVC_adaptiveSkipBack

### DIFF
--- a/c2_components/src/mfx_c2_decoder_component.cpp
+++ b/c2_components/src/mfx_c2_decoder_component.cpp
@@ -1643,7 +1643,7 @@ void MfxC2DecoderComponent::DoWork(std::unique_ptr<C2Work>&& work)
 
         {
             std::lock_guard<std::mutex> lock(m_readViewMutex);
-            m_readViews.emplace(work->input.ordinal.timestamp, std::move(read_view));
+            m_readViews.emplace(incoming_frame_index, std::move(read_view));
         }
 
         if (work->input.buffers.size() == 0) break;
@@ -1914,12 +1914,13 @@ void MfxC2DecoderComponent::WaitWork(MfxC2FrameOut&& frame_out, mfxSyncPoint syn
     {
         std::lock_guard<std::mutex> lock(m_readViewMutex);
 
-        auto it = m_readViews.find(ready_timestamp);
-
-        if (it != m_readViews.end()) {
-            read_view = std::move(it->second);
-            read_view.reset();
-            m_readViews.erase(it);
+        if (work) {
+            auto it = m_readViews.find(work->input.ordinal.frameIndex);
+            if (it != m_readViews.end()) {
+                read_view = std::move(it->second);
+                read_view.reset();
+                m_readViews.erase(it);
+            }
         }
     }
 


### PR DESCRIPTION
Root cause is that the timestamp of incoming bitsreams
may be the same, so we cannot use the timestamp info
to release the bitstream. Instead, the frame index of
current bitsream is unique, replace the timestamp with
frame index while releasing the bitstream.

Tracked-On: OAM-101098
Signed-off-by: Chen, Tianmi <tianmi.chen@intel.com>