### PR TITLE
[c2][encode] Fixed SurfaceEncodeTimestampTest failures

### DIFF
--- a/c2_utils/src/mfx_defaults.cpp
+++ b/c2_utils/src/mfx_defaults.cpp
@@ -145,6 +145,7 @@ mfxStatus mfx_set_defaults_mfxVideoParam_enc(mfxVideoParam* params)
         memset(params, 0, sizeof(mfxVideoParam));
         params->mfx.CodecId = CodecId;
         params->mfx.NumThread = 0;
+        params->AsyncDepth = 1;
 
         mfx_set_defaults_mfxFrameInfo(&params->mfx.FrameInfo);
 


### PR DESCRIPTION
case: android.media.cts.SurfaceEncodeTimestampTest

With AsyncDepth=1, mediaSDK will synchronize after encoding of
each frame. But with AsyncDepth=0, mediaSDK will set AsyncDepth
to larger than 1, synchronizing will be latency.

Tracked-On: OAM-101120
Signed-off-by: zhangyichix <yichix.zhang@intel.com>