### PR TITLE
Specical handling for odd video width

### DIFF
--- a/c2_buffers/src/mfx_c2_frame_out.cpp
+++ b/c2_buffers/src/mfx_c2_frame_out.cpp
@@ -43,12 +43,6 @@ c2_status_t MfxC2FrameOut::Create(const std::shared_ptr<MfxFrameConverter>& fram
             break;
         }
 
-        if ( (info.Width && info.Width > block->width()) ||
-             (info.Height && info.Height > block->height()) ) {
-            res = C2_BAD_VALUE;
-            break;
-        }
-
         uint64_t timestamp = 0;
         uint64_t frame_index = 0;
 

--- a/c2_components/src/mfx_c2_decoder_component.cpp
+++ b/c2_components/src/mfx_c2_decoder_component.cpp
@@ -127,10 +127,10 @@ MfxC2DecoderComponent::MfxC2DecoderComponent(const C2String name, const CreateCo
         [this] (C2StreamCropRectInfo::output* dst)->bool {
             MFX_DEBUG_TRACE("GetCropRect");
             // Called from Query, m_mfxVideoParams is already protected there with lock on m_initDecoderMutex
-            dst->width = m_mfxVideoParams.mfx.FrameInfo.CropW; // default width
-            dst->height = m_mfxVideoParams.mfx.FrameInfo.CropH; // default height
-            dst->left = m_mfxVideoParams.mfx.FrameInfo.CropX = 0;
-            dst->top = m_mfxVideoParams.mfx.FrameInfo.CropY = 0;
+            dst->width = m_mfxVideoParams.mfx.FrameInfo.CropW;
+            dst->height = m_mfxVideoParams.mfx.FrameInfo.CropH;
+            dst->left = m_mfxVideoParams.mfx.FrameInfo.CropX;
+            dst->top = m_mfxVideoParams.mfx.FrameInfo.CropY;
             MFX_DEBUG_TRACE_STREAM(NAMED(dst->left) << NAMED(dst->top) <<
                 NAMED(dst->width) << NAMED(dst->height));
             return true;
@@ -1531,7 +1531,7 @@ c2_status_t MfxC2DecoderComponent::AllocateFrame(MfxC2FrameOut* frame_out)
         }
 
         std::shared_ptr<C2GraphicBlock> out_block;
-        res = AllocateC2Block(m_mfxVideoParams.mfx.FrameInfo.Width, m_mfxVideoParams.mfx.FrameInfo.Height,
+        res = AllocateC2Block(MFXGetSurfaceWidth(m_mfxVideoParams.mfx.FrameInfo), MFXGetSurfaceHeight(m_mfxVideoParams.mfx.FrameInfo),
                               m_mfxVideoParams.mfx.FrameInfo.FourCC, &out_block);
         if (C2_TIMED_OUT == res) continue;
 

--- a/c2_utils/include/mfx_defs.h
+++ b/c2_utils/include/mfx_defs.h
@@ -199,3 +199,6 @@ uint32_t MFXGetFreeSurfaceIdx(mfxFrameSurface1 *SurfacesPool, uint32_t nPoolSize
 
 mfxStatus MFXAllocSystemMemorySurfacePool(uint8_t **buf, mfxFrameSurface1 *surfpool, mfxFrameInfo frame_info, uint32_t surfnum);
 void MFXFreeSystemMemorySurfacePool(uint8_t *buf, mfxFrameSurface1 *surfpool);
+
+uint32_t MFXGetSurfaceWidth(mfxFrameInfo info);
+uint32_t MFXGetSurfaceHeight(mfxFrameInfo info);

--- a/c2_utils/src/mfx_defs.cpp
+++ b/c2_utils/src/mfx_defs.cpp
@@ -29,6 +29,12 @@ static void InitMfxFrameHeader(
     uint32_t width, uint32_t height, uint32_t fourcc, const mfxFrameInfo& info, mfxFrameSurface1* mfx_frame)
 {
     MFX_DEBUG_TRACE_FUNC;
+    MFX_DEBUG_TRACE_I32(width);
+    MFX_DEBUG_TRACE_I32(height);
+    MFX_DEBUG_TRACE_I32(info.Width);
+    MFX_DEBUG_TRACE_I32(info.Height);
+    MFX_DEBUG_TRACE_I32(info.CropW);
+    MFX_DEBUG_TRACE_I32(info.CropH);
 
     mfx_frame->Info = info;//apply component's mfxFrameInfo
     mfx_frame->Info.CropW = width;
@@ -222,4 +228,30 @@ void MFXFreeSystemMemorySurfacePool(uint8_t *buf, mfxFrameSurface1 *surfpool)
 
     if (surfpool)
         free(surfpool);
+}
+
+uint32_t MFXGetSurfaceWidth(mfxFrameInfo info)
+{
+    MFX_DEBUG_TRACE_FUNC;
+
+    uint32_t width = info.Width;
+    if (info.CropW % 16) {
+        width = (info.Width == MFX_MEM_ALIGN(info.CropW, 16)) ? info.CropW : info.Width;
+    }
+
+    MFX_DEBUG_TRACE_I32(width);
+    return width;
+}
+
+uint32_t  MFXGetSurfaceHeight(mfxFrameInfo info)
+{
+    MFX_DEBUG_TRACE_FUNC;
+
+    uint32_t height = info.Height;
+    if (info.CropW % 16) {
+        height = (info.Height == MFX_MEM_ALIGN(info.CropH, 16)) ? info.CropH : info.Height;
+    }
+
+    MFX_DEBUG_TRACE_I32(height);
+    return height;
 }

--- a/c2_utils/src/mfx_va_frame_pool_allocator.cpp
+++ b/c2_utils/src/mfx_va_frame_pool_allocator.cpp
@@ -66,6 +66,8 @@ mfxStatus MfxVaFramePoolAllocator::AllocFrames(mfxFrameAllocRequest *request,
     MFX_DEBUG_TRACE_I32(request->NumFrameSuggested);
     MFX_DEBUG_TRACE_I32(request->Info.Width);
     MFX_DEBUG_TRACE_I32(request->Info.Height);
+    MFX_DEBUG_TRACE_I32(request->Info.CropW);
+    MFX_DEBUG_TRACE_I32(request->Info.CropH);
     MFX_DEBUG_TRACE_I64(m_consumerUsage);
 
     if (request->Type & MFX_MEMTYPE_VIDEO_MEMORY_DECODER_TARGET) {
@@ -110,7 +112,7 @@ mfxStatus MfxVaFramePoolAllocator::AllocFrames(mfxFrameAllocRequest *request,
                 int retry_time_left = RETRY_TIMES;
                 do {
                     res = m_c2Allocator->fetchGraphicBlock(
-                        request->Info.Width, request->Info.Height,
+                        MFXGetSurfaceWidth(request->Info), MFXGetSurfaceHeight(request->Info),
                         MfxFourCCToGralloc(request->Info.FourCC),
                         { m_consumerUsage, C2AndroidMemoryUsage::HW_CODEC_WRITE },
                         &new_block);


### PR DESCRIPTION
In case the decoded width parsed from bitstream is
not 16bit aligned, mediasdk or onevpl will force it
to 16byte aligned. Use display width and height to
create surface to avoid failure for below test case.

android.media.cts.DecodeAccuracyTest#testSurfaceViewLargerHeightDecodeAccuracy[23]
android.media.cts.DecodeAccuracyTest#testSurfaceViewLargerWidthDecodeAccuracy[23]
android.media.cts.DecodeAccuracyTest#testSurfaceViewVideoDecodeAccuracy[23]

Tracked-On: OAM-101186
Signed-off-by: Chen, Tianmi <tianmi.chen@intel.com>