### PR TITLE
Fixed stride issue when system memory is used

### DIFF
--- a/c2_buffers/src/mfx_c2_frame_out.cpp
+++ b/c2_buffers/src/mfx_c2_frame_out.cpp
@@ -43,6 +43,16 @@ c2_status_t MfxC2FrameOut::Create(const std::shared_ptr<MfxFrameConverter>& fram
             break;
         }
 
+        if ( (info.Width && info.Width > MFX_ALIGN_16(block->width())) ||
+             (info.Height && info.Height > MFX_ALIGN_16(block->height())) ) {
+            MFX_DEBUG_TRACE_I32(info.Width);
+            MFX_DEBUG_TRACE_I32(info.Height);
+            MFX_DEBUG_TRACE_I32(block->width());
+            MFX_DEBUG_TRACE_I32(block->height());
+            res = C2_BAD_VALUE;
+            break;
+        }
+
         uint64_t timestamp = 0;
         uint64_t frame_index = 0;
 
@@ -95,8 +105,12 @@ c2_status_t MfxC2FrameOut::Create(std::shared_ptr<C2GraphicBlock> block,
             break;
         }
 
-        if ( (info.Width && info.Width > block->width()) ||
-             (info.Height && info.Height > block->height()) ) {
+        if ( (info.Width && info.Width > MFX_ALIGN_16(block->width())) ||
+             (info.Height && info.Height > MFX_ALIGN_16(block->height())) ) {
+            MFX_DEBUG_TRACE_I32(info.Width);
+            MFX_DEBUG_TRACE_I32(info.Height);
+            MFX_DEBUG_TRACE_I32(block->width());
+            MFX_DEBUG_TRACE_I32(block->height());
             res = C2_BAD_VALUE;
             break;
         }

--- a/c2_utils/include/mfx_defs.h
+++ b/c2_utils/include/mfx_defs.h
@@ -76,7 +76,8 @@ extern mfxVersion g_required_mfx_version;
 
 #define MFX_MEM_ALIGN(X, N) ((X) & ((N)-1)) ? (((X)+(N)-1) & (~((N)-1))): (X)
 
-#define MFX_ALIGN_32(X) (((mfxU32)((X)+31)) & (~ (mfxU32)31))
+#define MFX_ALIGN_16(X) ((((X) + 15) >> 4) << 4)
+#define MFX_ALIGN_32(X) ((((X) + 31) >> 5) << 5)
 
 #define MFX_GET_ARRAY_SIZE(_array) \
     (sizeof(_array) / sizeof(_array[0]))
@@ -200,5 +201,5 @@ uint32_t MFXGetFreeSurfaceIdx(mfxFrameSurface1 *SurfacesPool, uint32_t nPoolSize
 mfxStatus MFXAllocSystemMemorySurfacePool(uint8_t **buf, mfxFrameSurface1 *surfpool, mfxFrameInfo frame_info, uint32_t surfnum);
 void MFXFreeSystemMemorySurfacePool(uint8_t *buf, mfxFrameSurface1 *surfpool);
 
-uint32_t MFXGetSurfaceWidth(mfxFrameInfo info);
-uint32_t MFXGetSurfaceHeight(mfxFrameInfo info);
+uint32_t MFXGetSurfaceWidth(mfxFrameInfo info, bool using_video_memory = true);
+uint32_t MFXGetSurfaceHeight(mfxFrameInfo info, bool using_video_memory = true);


### PR DESCRIPTION
Use stride got from GraphicView instead of video width
when system memory is used.

android.media.cts.ImageReaderDecoderTest#testOtherH264Image
android.media.cts.ImageReaderDecoderTest#testOtherH265Image
android.media.cts.ImageReaderDecoderTest#testOtherVP8Image
android.media.cts.ImageReaderDecoderTest#testOtherVP9Image
android.media.cts.ImageReaderDecoderTest#testOtherVP8ImageReader

Tracked-On: OAM-101198
Signed-off-by: Chen, Tianmi <tianmi.chen@intel.com>