### PR TITLE
[c2][decoder] Disable mpeg2 decoder

### DIFF
--- a/c2_store/data/media_codecs_intel_c2_video.xml
+++ b/c2_store/data/media_codecs_intel_c2_video.xml
@@ -62,7 +62,7 @@ and updated to vendor media codecs.
             <Limit name="performance-point-3840x2160" value="30" />
             <Feature name="adaptive-playback" />
         </MediaCodec>
-        <MediaCodec name="c2.intel.mp2.decoder" type="video/mpeg2">
+        <!--MediaCodec name="c2.intel.mp2.decoder" type="video/mpeg2">
             <Limit name="size" min="64x64" max="2048x2048" />
             <Limit name="alignment" value="2x2" />
             <Limit name="block-size" value="16x16" />
@@ -71,7 +71,7 @@ and updated to vendor media codecs.
             <Limit name="bitrate" range="1-40000000" />
             <Limit name="performance-point-1920x1080" value="30" />
             <Feature name="adaptive-playback" />
-        </MediaCodec>
+        </MediaCodec-->
         <MediaCodec name="c2.intel.av1.decoder" type="video/av01">
             <Limit name="size" min="64x64" max="4096x4096" />
             <Limit name="alignment" value="2x2" />

--- a/c2_store/data/mfx_c2_store.conf
+++ b/c2_store/data/mfx_c2_store.conf
@@ -5,5 +5,4 @@ c2.intel.hevc.encoder : libmfx_c2_components_hw.so
 c2.intel.vp9.encoder : libmfx_c2_components_hw.so
 c2.intel.vp9.decoder : libmfx_c2_components_hw.so
 c2.intel.vp8.decoder : libmfx_c2_components_hw.so
-c2.intel.mp2.decoder : libmfx_c2_components_hw.so
 c2.intel.av1.decoder : libmfx_c2_components_hw.so


### PR DESCRIPTION
Mpeg2 is no longer supported.

Tracked-On: OAM-102083
Signed-off-by: zhangyichix <yichix.zhang@intel.com>