### PR TITLE
[c2][encode] Fixed an issue which dynamic modification of bitrate failed

### DIFF
--- a/c2_components/src/mfx_c2_encoder_component.cpp
+++ b/c2_components/src/mfx_c2_encoder_component.cpp
@@ -1589,16 +1589,33 @@ void MfxC2EncoderComponent::DoConfig(const std::vector<C2Param*> &params,
                 m_mfxVideoParamsConfig.mfx.FrameInfo.FrameRateExtD = 1000;
                 break;
             }
-            case kParamIndexBitrate:
+            case kParamIndexBitrate: {
+                // MFX_RATECONTROL_CQP parameter is valid only during initialization.
                 if (m_mfxVideoParamsConfig.mfx.RateControlMethod != MFX_RATECONTROL_CQP) {
                     uint32_t bitrate_value = static_cast<const C2BitrateTuning*>(param)->value;
                     if (m_state == State::STOPPED) {
                         m_mfxVideoParamsConfig.mfx.TargetKbps = bitrate_value / 1000; // Convert from bps to Kbps
-                    } else if (m_mfxVideoParamsConfig.mfx.RateControlMethod == MFX_RATECONTROL_VBR) {
+                    } else {
                         auto update_bitrate_value = [this, bitrate_value, queue_update, failures, param] () {
-                            MFX_DEBUG_TRACE("update_bitrate_value");
-                            MFX_DEBUG_TRACE_I32(bitrate_value);
+                            MFX_DEBUG_TRACE_FUNC;
+                            // MDSK strongly recommended to retrieve the actual working parameters by MFXVideoENCODE_GetVideoParam
+                            // function before making any changes to bitrate settings.
+                            mfxStatus mfx_res = m_mfxEncoder->GetVideoParam(&m_mfxVideoParamsConfig);
+                            if (MFX_ERR_NONE != mfx_res) {
+                                MFX_DEBUG_TRACE__mfxStatus(mfx_res);
+                                return;
+                            }
                             m_mfxVideoParamsConfig.mfx.TargetKbps = bitrate_value / 1000; // Convert from bps to Kbps
+                            // If application sets NalHrdConformance option in mfxExtCodingOption structure to ON, the only allowed bitrate control mode is VBR.
+                            // If OFF, all bitrate control modes are available.In CBR and AVBR modes the application can
+                            // change TargetKbps, in VBR mode the application can change TargetKbps and MaxKbps values.
+                            // Such change in bitrate will not result in generation of a new key-frame or sequence header.
+                            if ((m_encoderType == ENCODER_H264 || m_encoderType == ENCODER_H265) &&
+                                m_mfxVideoParamsConfig.mfx.RateControlMethod != MFX_RATECONTROL_VBR) {
+                                mfxExtCodingOption* codingOption = m_mfxVideoParamsConfig.AddExtBuffer<mfxExtCodingOption>();
+                                codingOption->NalHrdConformance = MFX_CODINGOPTION_OFF;
+                            }
+
                             if (nullptr != m_mfxEncoder) {
                                 {   // waiting for encoding completion of all enqueued frames
                                     std::unique_lock<std::mutex> lock(m_devBusyMutex);
@@ -1620,6 +1637,8 @@ void MfxC2EncoderComponent::DoConfig(const std::vector<C2Param*> &params,
                             }
                         };
 
+                        MFX_DEBUG_TRACE_PRINTF("updating bitrate from %d to %d.",
+                                m_mfxVideoParamsConfig.mfx.TargetKbps, bitrate_value / 1000);
                         Drain(nullptr);
 
                         if (queue_update) {
@@ -1627,17 +1646,13 @@ void MfxC2EncoderComponent::DoConfig(const std::vector<C2Param*> &params,
                         } else {
                             update_bitrate_value();
                         }
-                    } else {
-                        // If state is executing and rate control is not VBR, Reset will not update bitrate,
-                        // so report an error.
-                        failures->push_back(MakeC2SettingResult(C2ParamField(param),
-                            C2SettingResult::CONFLICT, MakeVector(MakeC2ParamField<C2RateControlSetting>())));
                     }
                 } else {
                     failures->push_back(MakeC2SettingResult(C2ParamField(param),
                         C2SettingResult::CONFLICT, MakeVector(MakeC2ParamField<C2RateControlSetting>())));
                 }
                 break;
+            }
             case kParamIndexBitrateMode: {
                 C2Config::bitrate_mode_t c2_bitmode = static_cast<const C2StreamBitrateModeTuning*>(param)->value;
                 int32_t bitrate_mode = -1;

--- a/c2_utils/include/mfx_c2_utils.h
+++ b/c2_utils/include/mfx_c2_utils.h
@@ -202,6 +202,9 @@ private:
 //declare used extension buffers
 template<class T>
 struct mfx_ext_buffer_id{};
+template<>struct mfx_ext_buffer_id<mfxExtCodingOption> {
+    enum {id = MFX_EXTBUFF_CODING_OPTION};
+};
 template<>struct mfx_ext_buffer_id<mfxExtCodingOptionSPSPPS> {
     enum {id = MFX_EXTBUFF_CODING_OPTION_SPSPPS};
 };


### PR DESCRIPTION
case: android.media.cts.VideoCodecTest#testDynamicBitrateChangeHEVCNdkCBR
android.media.cts.VideoCodecTest#testDynamicBitrateChangeHEVCNdkVBR
android.media.cts.VideoCodecTest#testDynamicBitrateChangeVP9NdkCBR
android.media.cts.VideoCodecTest#testDynamicBitrateChangeVP9NdkVBR

If application sets NalHrdConformance option in mfxExtCodingOption
structure to ON, the only allowed bitrate control mode is VBR. If OFF,
all bitrate control modes are available.

Tracked-On: OAM-101252
Signed-off-by: zhangyichix <yichix.zhang@intel.com>