### PR TITLE
Revert "[c2][encode] Fixed SurfaceEncodeTimestampTest failures"

### DIFF
--- a/c2_utils/src/mfx_defaults.cpp
+++ b/c2_utils/src/mfx_defaults.cpp
@@ -145,7 +145,6 @@ mfxStatus mfx_set_defaults_mfxVideoParam_enc(mfxVideoParam* params)
         memset(params, 0, sizeof(mfxVideoParam));
         params->mfx.CodecId = CodecId;
         params->mfx.NumThread = 0;
-        params->AsyncDepth = 1;
 
         mfx_set_defaults_mfxFrameInfo(&params->mfx.FrameInfo);
 


### PR DESCRIPTION
This reverts commit 49655178008f778bbe388e85a756a7ce8d98f666.