### PR TITLE
[c2][memory] Fixed memory leak in InitSession

### DIFF
--- a/c2_components/src/mfx_c2_decoder_component.cpp
+++ b/c2_components/src/mfx_c2_decoder_component.cpp
@@ -611,7 +611,9 @@ mfxStatus MfxC2DecoderComponent::InitSession()
     mfxConfig cfg[2];
     mfxVariant cfgVal[2];
 
-    m_mfxLoader = MFXLoad();
+    if (nullptr == m_mfxLoader)
+        m_mfxLoader = MFXLoad();
+
     if (nullptr == m_mfxLoader) {
         ALOGE("MFXLoad failed...is implementation in path?");
         return MFX_ERR_UNKNOWN;

--- a/c2_components/src/mfx_c2_encoder_component.cpp
+++ b/c2_components/src/mfx_c2_encoder_component.cpp
@@ -430,7 +430,9 @@ mfxStatus MfxC2EncoderComponent::InitSession()
     mfxConfig cfg[2];
     mfxVariant cfgVal[2];
 
-    m_mfxLoader = MFXLoad();
+    if (nullptr == m_mfxLoader)
+        m_mfxLoader = MFXLoad();
+
     if (nullptr == m_mfxLoader) {
         ALOGE("MFXLoad failed...is implementation in path?");
         return MFX_ERR_UNKNOWN;


### PR DESCRIPTION
InitSession will called multiple times, which will cause MFXload to
also be called multiple time. Each call overwrites the previous pointer
that was not freed so it makes a memory leak.

Tracked-On: OAM-102284
Signed-off-by: zhangyichix <yichix.zhang@intel.com>