### PR TITLE
Fixed decoder time out issue in case of duplicated timestamp

### DIFF
--- a/c2_components/include/mfx_c2_decoder_component.h
+++ b/c2_components/include/mfx_c2_decoder_component.h
@@ -135,6 +135,14 @@ private:
 
     void DoWork(std::unique_ptr<C2Work>&& work);
 
+    void ReleaseReadViews(uint64_t incoming_frame_index);
+
+    void EmptyReadViews(uint64_t timestamp, uint64_t frame_index);
+
+    bool IsPartialFrame(uint64_t frame_index);
+
+    bool IsDuplicatedTimeStamp(uint64_t timestamp);
+
     void Drain(std::unique_ptr<C2Work>&& work);
     // waits for the sync_point and update work with decoder output then
     void WaitWork(MfxC2FrameOut&& frame_out, mfxSyncPoint sync_point);
@@ -212,7 +220,8 @@ private:
     std::list<std::unique_ptr<C2Work>> m_flushedWorks;
 
     std::mutex m_readViewMutex;
-    std::map<decltype(C2WorkOrdinalStruct::timestamp), std::unique_ptr<C2ReadView>> m_readViews;
+    std::map<const uint64_t, std::unique_ptr<C2ReadView>> m_readViews;
+    std::list<std::pair<uint64_t, uint64_t>> m_duplicatedTimeStamp;
 
     std::shared_ptr<C2StreamHdrStaticInfo::output> m_hdrStaticInfo;
     bool m_bSetHdrStatic;


### PR DESCRIPTION
This issue is to fix decoder timeout issue while dequeuing
input buffers. The root cause is that no input buffer returned
to codec2.0 framework in case of receving buffers with duplicated
timestamp.

Tracked-On: OAM-101354
Signed-off-by: Chen, Tianmi <tianmi.chen@intel.com>