### PR TITLE
Return empty work in case EOS comes early

### DIFF
--- a/c2_components/include/mfx_c2_decoder_component.h
+++ b/c2_components/include/mfx_c2_decoder_component.h
@@ -143,6 +143,8 @@ private:
 
     bool IsDuplicatedTimeStamp(uint64_t timestamp);
 
+    void FillEmptyWork(std::unique_ptr<C2Work>&& work, c2_status_t res);
+
     void Drain(std::unique_ptr<C2Work>&& work);
     // waits for the sync_point and update work with decoder output then
     void WaitWork(MfxC2FrameOut&& frame_out, mfxSyncPoint sync_point);


### PR DESCRIPTION
android.mediav2.cts.CodecDecoderTest#testOnlyEos
android.mediav2.cts.CodecDecoderTest#testOnlyEosNative

With above test cases, EOS comes but decoder not started
yet. In this case, we need to return empty work to prevent
timeout issue in codec2.0 framework.

Tracked-On: OAM-102475
Signed-off-by: Chen, Tianmi <tianmi.chen@intel.com>