### PR TITLE
Fixed some issues in VtsHalMediaC2V1_0

### DIFF
--- a/c2_components/include/mfx_c2_encoder_component.h
+++ b/c2_components/include/mfx_c2_encoder_component.h
@@ -132,7 +132,7 @@ private:
 
     void Drain(std::unique_ptr<C2Work>&& work);
 
-    void ReturnEmptyWork(std::unique_ptr<C2Work>&& work);
+    void ReturnEmptyWork(std::unique_ptr<C2Work>&& work, c2_status_t res);
     // waits for the sync_point and update work with encoder output then
     void WaitWork(std::unique_ptr<C2Work>&& work,
         std::unique_ptr<mfxEncodeCtrl>&& encode_ctrl,
@@ -143,6 +143,8 @@ private:
     std::shared_ptr<C2StreamColorAspectsInfo::output> getCodedColorAspects_l();
 
     bool CodedColorAspectsDiffer(std::shared_ptr<C2StreamColorAspectsInfo::output> vuiColorAspects);
+
+    void getMaxMinResolutionSupported(uint32_t *min_w, uint32_t *min_h, uint32_t *max_w, uint32_t *max_h);
 
 private:
     EncoderType m_encoderType;

--- a/c2_components/src/mfx_c2_component.cpp
+++ b/c2_components/src/mfx_c2_component.cpp
@@ -384,7 +384,7 @@ c2_status_t MfxC2Component::stop()
 c2_status_t MfxC2Component::reset()
 {
     MFX_DEBUG_TRACE_FUNC;
-    return C2_OMITTED;
+    return C2_OK;
 }
 
 c2_status_t MfxC2Component::release()

--- a/c2_utils/include/mfx_c2_utils.h
+++ b/c2_utils/include/mfx_c2_utils.h
@@ -217,7 +217,9 @@ template<>struct mfx_ext_buffer_id<mfxExtVP9Param> {
 template<>struct mfx_ext_buffer_id<mfxExtVideoSignalInfo> {
     enum {id = MFX_EXTBUFF_VIDEO_SIGNAL_INFO };
 };
-
+template<>struct mfx_ext_buffer_id<mfxExtEncoderResetOption> {
+    enum {id = MFX_EXTBUFF_ENCODER_RESET_OPTION };
+};
 
 template <typename R>
 struct ExtParamAccessor
@@ -408,6 +410,7 @@ private:
             MFX_EXTBUFF_HEVC_PARAM,
             MFX_EXTBUFF_VP9_PARAM,
             MFX_EXTBUFF_VIDEO_SIGNAL_INFO,
+            MFX_EXTBUFF_ENCODER_RESET_OPTION
         };
 
         auto it = std::find_if(std::begin(allowed), std::end(allowed),

--- a/c2_utils/src/mfx_cmd_queue.cpp
+++ b/c2_utils/src/mfx_cmd_queue.cpp
@@ -119,8 +119,7 @@ void MfxCmdQueue::Process()
         WaitingPop(&mfx_cmd);
         if(mfx_cmd == nullptr) {
             break;
-        }
-        else {
+        } else {
             mfx_cmd();
         }
     }


### PR DESCRIPTION
This change includes,
1. Add API to query max and min resolution supported in encoder
2. Pass EOS flags if any in case codec2.0 failed unexpectedly
3. Return correct status for component reset
4. Add sanity check if invalid buffer sent to encoder
5. Refined bitrate control mode
6. Removed some tabs

Tracked-On: OAM-102693
Signed-off-by: Chen, Tianmi <tianmi.chen@intel.com>