### PR TITLE
Fixed recorded video not seek issue

### DIFF
--- a/c2_components/include/mfx_c2_encoder_component.h
+++ b/c2_components/include/mfx_c2_encoder_component.h
@@ -146,6 +146,8 @@ private:
 
     void getMaxMinResolutionSupported(uint32_t *min_w, uint32_t *min_h, uint32_t *max_w, uint32_t *max_h);
 
+    uint32_t getSyncFramePeriod_l(int32_t sync_frame_period) const;
+
 private:
     EncoderType m_encoderType;
 


### PR DESCRIPTION
The root cause is that the I frame interval is
not calculated correctly, thus only one IDR frame
is encoded for all the sequences, which results in
recorded video unable to seek.

Tracked-On: OAM-102237
Signed-off-by: Chen, Tianmi <tianmi.chen@intel.com>