### PR TITLE
[c2][decoder] Increase the input pipeline count

### DIFF
--- a/c2_components/include/mfx_c2_decoder_component.h
+++ b/c2_components/include/mfx_c2_decoder_component.h
@@ -240,5 +240,5 @@ private:
     std::list<std::shared_ptr<mfxFrameSurface1>> m_surfacePool; // used in case of system memory
 
     unsigned int m_uOutputDelay = 8u;
-    unsigned int m_uInputDelay = 0u;
+    unsigned int m_uInputDelay = 12u;
 };


### PR DESCRIPTION
case:android.mediav2.cts.CodecDecoderPauseTest#testPause[2(c2.intel.hevc.decoder_video/hevc)]

Since the sps_max_num_reorder_pics value of some videos is relatively large,
more frames need to be referenced, so increase the input pipeline count.

Tracked-On: OAM-102845
Signed-off-by: zhangyichix <yichix.zhang@intel.com>