### PR TITLE
Revert "[STS] fix for sts StagefrightTest failures"

### DIFF
--- a/c2_components/src/mfx_c2_decoder_component.cpp
+++ b/c2_components/src/mfx_c2_decoder_component.cpp
@@ -1501,9 +1501,7 @@ mfxStatus MfxC2DecoderComponent::DecodeFrame(mfxBitstream *bs, MfxC2FrameOut&& f
                         ++m_uSyncedPointsCount;
                     }
                 }
-	    } else {
-		*expect_output = false;
-	      }
+            }
         } else if (MFX_ERR_INCOMPATIBLE_VIDEO_PARAM == mfx_sts) {
             MFX_DEBUG_TRACE_MSG("MFX_ERR_INCOMPATIBLE_VIDEO_PARAM: resolution was changed");
         }


### PR DESCRIPTION
This reverts commit 2c652c7b1d56ff01a850cd90c92633de9a826e54.

Although surface_out is null when mfx_sts = MFX_ERR_MORE_DATA,
still expect output on next work.

Signed-off-by: zhangyichix <yichix.zhang@intel.com>