### PR TITLE
Enable DRM primary memory type in Android T

### DIFF
--- a/mfx_c2_defs.mk
+++ b/mfx_c2_defs.mk
@@ -42,12 +42,7 @@ MFX_C2_CFLAGS += \
 
 ifeq ($(BOARD_USES_GRALLOC1),true)
   # plugins should use PRIME buffer descriptor since Android P
-  ifneq ($(filter MFX_S ,$(MFX_ANDROID_VERSION)),)
-      MFX_C2_CFLAGS += -DMFX_C2_USE_PRIME
-  endif
-  ifneq ($(filter MFX_R ,$(MFX_ANDROID_VERSION)),)
-      MFX_C2_CFLAGS += -DMFX_C2_USE_PRIME
-  endif
+  MFX_C2_CFLAGS += -DMFX_C2_USE_PRIME
 else
   $(error "Required GRALLOC1 support")
 endif


### PR DESCRIPTION
Enable DRM primary memory type in codec2.0

Tracked-On: OAM-101794
Signed-off-by: Chen, Tianmi <tianmi.chen@intel.com>