### PR TITLE
[c2][decoder] Caculate pitch by fourcc

### DIFF
--- a/c2_utils/include/mfx_c2_utils.h
+++ b/c2_utils/include/mfx_c2_utils.h
@@ -449,3 +449,46 @@ private:
 };
 
 using MfxVideoParamsWrapper = ExtBufHolder<mfxVideoParam>;
+
+// Ported from MSDK
+inline mfxU32 GetMinPitch(mfxU32 fourcc, mfxU16 width)
+{
+    switch (fourcc)
+    {
+        case MFX_FOURCC_P8:
+        case MFX_FOURCC_P8_TEXTURE:
+        case MFX_FOURCC_NV12:
+        case MFX_FOURCC_YV12:
+        case MFX_FOURCC_RGBP:
+        case MFX_FOURCC_BGRP:
+        case MFX_FOURCC_NV16:        return width * 1;
+        case MFX_FOURCC_RGB565:      return width * 2;
+        case MFX_FOURCC_R16:         return width * 2;
+
+        case MFX_FOURCC_RGB3:        return width * 3;
+
+        case MFX_FOURCC_AYUV:
+        case MFX_FOURCC_AYUV_RGB4:
+        case MFX_FOURCC_RGB4:
+        case MFX_FOURCC_BGR4:
+        case MFX_FOURCC_A2RGB10:     return width * 4;
+
+        case MFX_FOURCC_ARGB16:
+        case MFX_FOURCC_ABGR16:      return width * 8;
+
+        case MFX_FOURCC_YUY2:
+        case MFX_FOURCC_UYVY:        return width * 2;
+
+        case MFX_FOURCC_P010:
+        case MFX_FOURCC_P016:
+        case MFX_FOURCC_P210:        return width * 2;
+
+        case MFX_FOURCC_Y210:
+        case MFX_FOURCC_Y410:        return width * 4;
+
+        case MFX_FOURCC_Y216:        return width * 4;
+        case MFX_FOURCC_Y416:        return width * 8;
+    }
+
+    return 0;
+}

--- a/c2_utils/src/mfx_defs.cpp
+++ b/c2_utils/src/mfx_defs.cpp
@@ -62,33 +62,32 @@ mfxStatus InitMfxFrameSW(
     InitMfxFrameHeader(timestamp, frame_index, width, height, fourcc, info, mfx_frame);
 
     mfx_frame->Data.MemType = MFX_MEMTYPE_SYSTEM_MEMORY;
-    mfx_frame->Data.PitchLow = MFX_ALIGN_32(stride);
 
-    res = MFXLoadSurfaceSW(data, stride, input_info, mfx_frame);
+    res = MFXLoadSurfaceSW(data, GetMinPitch(fourcc, stride), input_info, mfx_frame);
 
     return res;
 }
 
-mfxStatus MFXLoadSurfaceSW(uint8_t *data, uint32_t stride, const mfxFrameInfo& input_info, mfxFrameSurface1* srf)
+mfxStatus MFXLoadSurfaceSW(uint8_t *data, uint32_t pitch, const mfxFrameInfo& input_info, mfxFrameSurface1* srf)
 {
     MFX_DEBUG_TRACE_FUNC;
     mfxStatus res = MFX_ERR_NONE;
 
-    uint32_t nOWidth = input_info.Width;
     uint32_t nOHeight = input_info.Height;
-    uint32_t nOPitch = stride;
+    uint32_t nOPitch = pitch;
 
     uint32_t nCropX = srf->Info.CropX;
     uint32_t nCropY = srf->Info.CropY;
     uint32_t nCropW = srf->Info.CropW;
     uint32_t nCropH = srf->Info.CropH;
-    uint32_t nPitch = srf->Data.PitchLow;
+    uint32_t nPitch = MFX_ALIGN_32(pitch);
+    srf->Data.PitchLow = nPitch;
 
     if (!MFX_C2_IS_COPY_NEEDED(srf->Data.MemType, input_info, srf->Info)) {
         srf->Data.Y  = data;
         srf->Data.U = data + nOPitch * nOHeight;
         srf->Data.V = srf->Data.U + 1;
-        srf->Data.Pitch = nOPitch;
+        srf->Data.PitchLow = nOPitch;
     } else {
         uint32_t i = 0;
         uint8_t* Y  = data;


### PR DESCRIPTION
cases:
android.mediav2.cts.CodecDecoderSurfaceTest#testFlushNative
android.mediav2.cts.CodecDecoderSurfaceTest#testSimpleDecodeToSurface
[0(c2.intel.av1.decoder_video/av01)]

The pitch should be width * 2 if fourcc is MFX_FOURCC_P010.

Tracked-On: OAM-103640
Signed-off-by: zhangyichix <yichix.zhang@intel.com>