### PR TITLE
[c2][decoder] Fixed av1 color aspect issue

### DIFF
--- a/c2_utils/src/mfx_c2_color_aspects_wrapper.cpp
+++ b/c2_utils/src/mfx_c2_color_aspects_wrapper.cpp
@@ -78,7 +78,7 @@ void MfxC2ColorAspectsWrapper::UpdateBitstreamColorAspects(const mfxExtVideoSign
                                             signalInfo.VideoFullRange != 0 ||
                                             signalInfo.ColourDescriptionPresent != 0;
 
-    if (MFX_CODEC_VP9 == m_uCodecId || MFX_CODEC_VP8 == m_uCodecId)
+    if (MFX_CODEC_VP9 == m_uCodecId || MFX_CODEC_VP8 == m_uCodecId || MFX_CODEC_AV1 == m_uCodecId)
     {
         video_signal_type_present_flag = false;
     }
@@ -156,7 +156,7 @@ void MfxC2ColorAspectsWrapper::GetColorAspectsFromVideoSignal(const mfxExtVideoS
                                             signalInfo.VideoFullRange != 0 ||
                                             signalInfo.ColourDescriptionPresent != 0;
 
-    if (MFX_CODEC_VP9 == m_uCodecId || MFX_CODEC_VP8 == m_uCodecId)
+    if (MFX_CODEC_VP9 == m_uCodecId || MFX_CODEC_VP8 == m_uCodecId || MFX_CODEC_AV1 == m_uCodecId)
     {
         // No video signal info present in vpx bitstream.
         video_signal_type_present_flag = false;


### PR DESCRIPTION
cases:
android.mediav2.cts.DecoderColorAspectsTest[2(c2.intel.av1.decoder_video/av01_1_2_4)]
android.mediav2.cts.DecoderColorAspectsTest[10(c2.intel.av1.decoder_video/av01_1_8_1)]
android.mediav2.cts.DecoderColorAspectsTest[14(c2.intel.av1.decoder_video/av01_1_6_7)]

MSDK doesn't specify the color aspect for av1 so far.

Tracked-On: OAM-103721
Signed-off-by: zhangyichix <yichix.zhang@intel.com>