### PR TITLE
[c2][decoder] Exit the loop when the surface may not be available

### DIFF
--- a/c2_components/include/mfx_c2_decoder_component.h
+++ b/c2_components/include/mfx_c2_decoder_component.h
@@ -42,6 +42,13 @@ public:
         DECODER_AV1,
     };
 
+    enum class OperationState {
+        INITIALIZATION,
+        RUNNING,
+        STOPPING,
+        STOPPED,
+    };
+
 protected:
     MfxC2DecoderComponent(const C2String name, const CreateConfig& config,
         std::shared_ptr<MfxC2ParamReflector> reflector, DecoderType decoder_type);
@@ -173,6 +180,8 @@ private:
     bool m_bAllocatorSet { false };
 
     bool m_bInitialized;
+
+    OperationState m_OperationState { OperationState::INITIALIZATION };
 
     MfxCmdQueue m_workingQueue;
     MFX_TRACEABLE(m_workingQueue);


### PR DESCRIPTION
cases:
android.media.decoder.cts.DecoderTest#testCodecResetsH264WithSurface android.media.decoder.cts.DecoderTest#testCodecResetsHEVCWithSurface

From Android T, Surfaces are no longer used when MediaCodec#stop() is called. 
https://android-review.googlesource.com/c/platform/frameworks/av/+/2098075 
Exit the loop when the surface may not be available.

Tracked-On: OAM-104001
Signed-off-by: zhangyichix <yichix.zhang@intel.com>