### PR TITLE
Modify the default value of the bitrate mode

### DIFF
--- a/c2_components/src/mfx_c2_encoder_component.cpp
+++ b/c2_components/src/mfx_c2_encoder_component.cpp
@@ -214,7 +214,7 @@ MfxC2EncoderComponent::MfxC2EncoderComponent(const C2String name, const CreateCo
         AllocUniqueString<C2PortMediaTypeSetting::input>("video/raw"));
 
     pr.AddValue(C2_PARAMKEY_BITRATE_MODE,
-        std::make_unique<C2StreamBitrateModeTuning::output>(SINGLE_STREAM_ID, C2Config::bitrate_mode_t::BITRATE_CONST));
+        std::make_unique<C2StreamBitrateModeTuning::output>(SINGLE_STREAM_ID, C2Config::bitrate_mode_t::BITRATE_VARIABLE));
 
     pr.AddValue(C2_PARAMKEY_REQUEST_SYNC_FRAME, 
         std::make_unique<C2StreamRequestSyncFrameTuning::output>(SINGLE_STREAM_ID, false));
@@ -1589,6 +1589,26 @@ c2_status_t MfxC2EncoderComponent::QueryParam(const mfxVideoParam* src, C2Param:
                     MFX_DEBUG_TRACE_U32(setting->transfer);
                     MFX_DEBUG_TRACE_U32(setting->matrix);
                 }
+                break;
+            }
+            case kParamIndexBitrateMode: {
+                if (nullptr == *dst) {
+                    *dst = new C2StreamBitrateModeTuning::output();
+                }
+
+                C2StreamBitrateModeTuning::output* setting = static_cast<C2StreamBitrateModeTuning::output*>(*dst);
+                switch (m_mfxVideoParamsConfig.mfx.RateControlMethod) {
+                    case MFX_RATECONTROL_CBR:
+                        setting->value = C2Config::bitrate_mode_t::BITRATE_CONST;
+                        break;
+                    case MFX_RATECONTROL_VBR:
+                        setting->value = C2Config::bitrate_mode_t::BITRATE_VARIABLE;
+                        break;
+                    default:
+                        setting->value = C2Config::bitrate_mode_t::BITRATE_IGNORE;
+                        break;
+                }
+                MFX_DEBUG_TRACE_STREAM("QueryParam BitrateMode = " << setting->value);
                 break;
             }
             default:


### PR DESCRIPTION
case:
android.mediav2.cts.EncodeDecodeAccuracyTest#testEncodeDecodeAccuracyRGB

With setting the default of bitrate mode to BITRATE_CONST and it will be not changed in the format by user, MediaCodecInfo.CodecCapabilities.isFormatSupported
 will return false.

Tracked-On: OAM-104455
Signed-off-by: zhangyichix <yichix.zhang@intel.com>
Signed-off-by: Kothapeta, BikshapathiX <bikshapathix.kothapeta@intel.com>