### PR TITLE
Remove unsupported Diagnostics Element in xml

### DIFF
--- a/c2_store/data/media_codecs_intel_c2_video.xml
+++ b/c2_store/data/media_codecs_intel_c2_video.xml
@@ -95,7 +95,6 @@ and updated to vendor media codecs.
             <Limit name="bitrate" range="1-12000000" />
             <Limit name="performance-point-3840x2160" value="30" />
             <!--Feature name="intra-refresh" /-->
-            <Diagnostics dumpOutput="false" />
         </MediaCodec>
         <MediaCodec name="c2.intel.hevc.encoder" type="video/hevc" >
             <Limit name="size" min="176x144" max="8192x8192" />


### PR DESCRIPTION
Element 'Diagnostics': This element is not expected Against the schema: "/data/local/tmp/media_codecs.xsd" fixing vts_mediaCodecs_validate_test

Tracked-On: OAM-104733
Signed-off-by: Kothapeta, BikshapathiX <bikshapathix.kothapeta@intel.com>