### PR TITLE
Dumping decoded buffer

### DIFF
--- a/c2_components/include/mfx_c2_decoder_component.h
+++ b/c2_components/include/mfx_c2_decoder_component.h
@@ -30,6 +30,7 @@
 #include "mfx_gralloc_allocator.h"
 #include "mfx_c2_color_aspects_wrapper.h"
 #include "mfx_c2_setters.h"
+#include <cutils/properties.h>
 
 class MfxC2DecoderComponent : public MfxC2Component
 {
@@ -250,6 +251,12 @@ private:
 
     unsigned int m_uOutputDelay = 8u;
     unsigned int m_uInputDelay = 0u;
+
+#if MFX_DEBUG_DUMP_FRAME == MFX_DEBUG_YES
+    int m_count = 0;
+    std::mutex m_count_lock;
+    bool NeedDumpBuffer();
+#endif
 
     /* -----------------------C2Parameters--------------------------- */
     std::shared_ptr<C2ComponentNameSetting> m_name;


### PR DESCRIPTION
Add property "mediacodec2.dump.buffer" for triggering dumping buffer

setenforce 0
setprop mediacodec2.dump.buffer X
to dumping X frames buffer into /data/local/traces/decoder_frame.yuv
for instance,
setprop mediacodec2.dump.buffer 100
dumping 100 frame buffers.

Tracked-On: OAM-105271
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>
