### PR TITLE
Fix for Vts MultipleStartStopReset

### DIFF
--- a/c2_components/src/mfx_c2_component.cpp
+++ b/c2_components/src/mfx_c2_component.cpp
@@ -384,7 +384,22 @@ c2_status_t MfxC2Component::stop()
 c2_status_t MfxC2Component::reset()
 {
     MFX_DEBUG_TRACE_FUNC;
-    return C2_OK;
+
+    c2_status_t res = C2_OK;
+
+    res = DoStop(true);
+
+    {
+	 std::lock_guard<std::mutex> lock(m_stateMutex);
+	 if (C2_OK == res) { // DoStop succeeded
+		 m_state = m_nextState = State::STOPPED;
+	 } else {
+		 m_nextState = m_state;
+	 }
+	 m_condStateStable.notify_all();
+    }
+
+    return res;
 }
 
 c2_status_t MfxC2Component::release()


### PR DESCRIPTION
The issue with MultipleStartStopReset is when we do start()->reset()->start(), the state is in RUNNING state, so start() is returning the C2_BAD_STATE.

Added the functionality for reset() method in mfx_c2_component for fixing the issue with the VtsHalMediaC2 module.

Tracked-On: OAM-103591
Signed-off-by: gollarx <ratnakumarix.golla@intel.com>