### PR TITLE
[c2][decoder] Reduce input buffer size

### DIFF
--- a/c2_components/src/mfx_c2_decoder_component.cpp
+++ b/c2_components/src/mfx_c2_decoder_component.cpp
@@ -42,7 +42,7 @@ using namespace android;
 constexpr uint32_t MIN_W = 176;
 constexpr uint32_t MIN_H = 144;
 constexpr c2_nsecs_t TIMEOUT_NS = MFX_SECOND_NS;
-constexpr uint64_t kMinInputBufferSize = 2 * WIDTH_2K * HEIGHT_2K;
+constexpr uint64_t kMinInputBufferSize = 2 * WIDTH_1K * HEIGHT_1K;
 constexpr uint64_t kDefaultConsumerUsage =
     (GRALLOC_USAGE_HW_TEXTURE | GRALLOC_USAGE_HW_COMPOSER);
 

--- a/c2_utils/include/mfx_defs.h
+++ b/c2_utils/include/mfx_defs.h
@@ -64,6 +64,9 @@ extern mfxVersion g_required_mfx_version;
 #define WIDTH_2K 2048
 #define HEIGHT_2K 2048
 
+#define WIDTH_1K 1024
+#define HEIGHT_1K 1024
+
 #define MIN_WIDTH_4K 3840
 #define MIN_HEIGHT_4K 2160
 #define MIN_WIDTH_8K 7680


### PR DESCRIPTION
related issue: OAM-105136

When the bitstream header is incomplete, component will cache a lot bitstream to find complete header info. In order to avoid excessive memory consumption, we reduce minimum input buffer size from 8M to 2M.

Tracked-On: OAM-105477
Signed-off-by: zhangyichix <yichix.zhang@intel.com>