### PR TITLE
MediaSDK_C2 refactor regression.

### DIFF
--- a/c2_components/include/mfx_c2_decoder_component.h
+++ b/c2_components/include/mfx_c2_decoder_component.h
@@ -215,7 +215,7 @@ private:
     std::shared_ptr<MfxFramePoolAllocator> m_allocator; // used when Video memory output
     // for pre-allocation when Video memory is chosen and always when System memory output
     std::shared_ptr<C2BlockPool> m_c2Allocator;
-    C2BlockPool::local_id_t m_outputPoolId = C2BlockPool::PLATFORM_START;
+    C2BlockPool::local_id_t m_outputPoolId = C2BlockPool::BASIC_GRAPHIC;
     std::unique_ptr<MfxGrallocAllocator> m_grallocAllocator;
     std::atomic<bool> m_bFlushing{false};
 

--- a/c2_components/src/mfx_c2_decoder_component.cpp
+++ b/c2_components/src/mfx_c2_decoder_component.cpp
@@ -1172,7 +1172,7 @@ mfxStatus MfxC2DecoderComponent::InitDecoder(std::shared_ptr<C2BlockPool> c2_all
             uint64_t usage, igbp_id;
             android::_UnwrapNativeCodec2GrallocMetadata(out_block->handle(), &width, &height, &format, &usage,
                                                         &stride, &generation, &igbp_id, &igbp_slot);
-            if (!igbp_id && !igbp_slot)
+            if ((!igbp_id && !igbp_slot) || (!igbp_id && igbp_slot == 0xffffffff))
             {
                 // No surface & BQ
                 m_mfxVideoParams.IOPattern = MFX_IOPATTERN_OUT_SYSTEM_MEMORY;

--- a/c2_components/src/mfx_c2_encoder_component.cpp
+++ b/c2_components/src/mfx_c2_encoder_component.cpp
@@ -942,6 +942,7 @@ mfxStatus MfxC2EncoderComponent::InitVPP(C2FrameData& buf_pack)
 
     std::unique_ptr<C2ConstGraphicBlock> c_graph_block;
     std::unique_ptr<const C2GraphicView> c2_graphic_view_;
+
     res = GetC2ConstGraphicBlock(buf_pack, &c_graph_block);
     if(C2_OK != res) return MFX_ERR_NONE;
 
@@ -976,7 +977,7 @@ mfxStatus MfxC2EncoderComponent::InitVPP(C2FrameData& buf_pack)
         uint64_t usage, igbp_id;
         android::_UnwrapNativeCodec2GrallocMetadata(c_graph_block->handle(), &width, &height, &format, &usage,
                                                 &stride, &generation, &igbp_id, &igbp_slot);
-        if (!igbp_id && !igbp_slot) {
+        if ((!igbp_id && !igbp_slot) || (!igbp_id && igbp_slot == 0xffffffff)) {
             //No surface & BQ
             m_mfxVideoParamsConfig.IOPattern = MFX_IOPATTERN_IN_SYSTEM_MEMORY;
 #ifdef USE_ONEVPL


### PR DESCRIPTION
Fixed Vts issue which fetch noncached blocks constantly

Set the default value of m_outputPoolId back to BASIC_GRAPHIC.

As VTS call the component’s function directly(skip codec) from HAL. So that we set the outputPoolId to PLATFORM_START, it will use the BUFFERQUEUE allocator, but no surface was set. That’s the reason
 igbp_id is 0 and igbp_slot is ~0(0xffffffff).

Tracked-On: OAM-105589
Signed-off-by: zhangyichix <yichix.zhang@intel.com>
Signed-off-by: Yang, Dong <dong.yang@intel.com>
Signed-off-by: gollarx <ratnakumarix.golla@intel.com>
Signed-off-by: Kothapeta, BikshapathiX <bikshapathix.kothapeta@intel.com>