### PR TITLE
[c2][decoder] Fixed Vts issue which fetch noncached blocks constantly…

### DIFF
--- a/c2_components/src/mfx_c2_decoder_component.cpp
+++ b/c2_components/src/mfx_c2_decoder_component.cpp
@@ -1175,7 +1175,7 @@ mfxStatus MfxC2DecoderComponent::InitDecoder(std::shared_ptr<C2BlockPool> c2_all
             uint64_t usage, igbp_id;
             android::_UnwrapNativeCodec2GrallocMetadata(out_block->handle(), &width, &height, &format, &usage,
                                                         &stride, &generation, &igbp_id, &igbp_slot);
-            if (!igbp_id && !igbp_slot)
+            if ((!igbp_id && !igbp_slot) || (!igbp_id && igbp_slot == 0xffffffff))
             {
                 // No surface & BQ
                 m_mfxVideoParams.IOPattern = MFX_IOPATTERN_OUT_SYSTEM_MEMORY;

--- a/c2_components/src/mfx_c2_encoder_component.cpp
+++ b/c2_components/src/mfx_c2_encoder_component.cpp
@@ -948,6 +948,7 @@ mfxStatus MfxC2EncoderComponent::InitVPP(C2FrameData& buf_pack)
 
     std::unique_ptr<C2ConstGraphicBlock> c_graph_block;
     std::unique_ptr<const C2GraphicView> c2_graphic_view_;
+
     res = GetC2ConstGraphicBlock(buf_pack, &c_graph_block);
     if(C2_OK != res) return MFX_ERR_NONE;
 
@@ -982,7 +983,7 @@ mfxStatus MfxC2EncoderComponent::InitVPP(C2FrameData& buf_pack)
         uint64_t usage, igbp_id;
         android::_UnwrapNativeCodec2GrallocMetadata(c_graph_block->handle(), &width, &height, &format, &usage,
                                                 &stride, &generation, &igbp_id, &igbp_slot);
-        if (!igbp_id && !igbp_slot) {
+        if ((!igbp_id && !igbp_slot) || (!igbp_id && igbp_slot == 0xffffffff)) {
             //No surface & BQ
             m_mfxVideoParamsConfig.IOPattern = MFX_IOPATTERN_IN_SYSTEM_MEMORY;
 #ifdef USE_ONEVPL


### PR DESCRIPTION
…(additional)

case: PerInstance/Codec2VideoDecHidlTest#AdaptiveDecodeTest/default_c2_intel_avc_decoder_1

With PR#76, still found some cases regression until applying both 2 patches together.

Tracked-On: OAM-105655
Signed-off-by: Yang, Dong <dong.yang@intel.com>
Signed-off-by: zhangyichix <yichix.zhang@intel.com>