### PR TITLE
Change the MinInputBufferSize to 1M and Make the size is aligned with 64

### DIFF
--- a/c2_components/src/mfx_c2_decoder_component.cpp
+++ b/c2_components/src/mfx_c2_decoder_component.cpp
@@ -42,7 +42,7 @@ using namespace android;
 constexpr uint32_t MIN_W = 176;
 constexpr uint32_t MIN_H = 144;
 constexpr c2_nsecs_t TIMEOUT_NS = MFX_SECOND_NS;
-constexpr uint64_t kMinInputBufferSize = 2 * WIDTH_1K * HEIGHT_1K;
+constexpr uint64_t kMinInputBufferSize = 1 * WIDTH_1K * HEIGHT_1K;
 constexpr uint64_t kDefaultConsumerUsage =
     (GRALLOC_USAGE_HW_TEXTURE | GRALLOC_USAGE_HW_COMPOSER);
 
@@ -88,7 +88,6 @@ C2R MfxC2DecoderComponent::MaxPictureSizeSetter(bool mayBlock, C2P<C2StreamMaxPi
     // TODO: get max width/height from the size's field helpers vs. hardcoding
     me.set().width = c2_min(c2_max(me.v.width, size.v.width), uint32_t(WIDTH_8K));
     me.set().height = c2_min(c2_max(me.v.height, size.v.height), uint32_t(HEIGHT_8K));
-    ALOGD("zyc, max.w = %d, h = %d", me.set().width, me.set().height);
     return C2R::Ok();
 }
 
@@ -96,10 +95,8 @@ C2R MfxC2DecoderComponent::MaxInputSizeSetter(bool mayBlock, C2P<C2StreamMaxBuff
                                 const C2P<C2StreamMaxPictureSizeTuning::output> &maxSize) {
     (void)mayBlock;
     // assume compression ratio of 2
-    me.set().value = c2_max((((maxSize.v.width + 15) / 16)
-            * ((maxSize.v.height + 15) / 16) * 192), kMinInputBufferSize);
-    ALOGD("zyc, input size = %d", me.set().value);
-    me.set().value = kMinInputBufferSize;
+    me.set().value = c2_max((((maxSize.v.width + 63) / 64) * ((maxSize.v.height + 63) / 64) * 3072),
+		   kMinInputBufferSize);
     return C2R::Ok();
 }
 


### PR DESCRIPTION
2M is used in Software Codec. and may cause memory overfllow in CTS. Reduce it to 1M.
HEVC required 64 aligned, AVC required 16 aligned. We keep the size 64 aligned for all formats

Tracked-On: OAM-105770
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>