### PR TITLE
Fix hevc testValidateProfileLevel

### DIFF
--- a/c2_components/src/mfx_c2_encoder_component.cpp
+++ b/c2_components/src/mfx_c2_encoder_component.cpp
@@ -344,7 +344,6 @@ MfxC2EncoderComponent::MfxC2EncoderComponent(const C2String name, const CreateCo
                         .oneOf({
                             PROFILE_HEVC_MAIN,
                             PROFILE_HEVC_MAIN_STILL,
-                            PROFILE_HEVC_MAIN_10,
                         }),
                     C2F(m_profileLevel, C2ProfileLevelStruct::level)
                         .oneOf({


### PR DESCRIPTION
Disable UNSUPPORTED PROFILE_HEVC_MAIN_10 as
For HEVC_MAIN10 profile, the bitdepth value should be 10. and currently, we don't support 10bit hevc encoding in mediasdk codec2.0.

Tracked-On: OAM-105730
Signed-off-by: Yang, Dong <dong.yang@intel.com>
Signed-off-by: Kothapeta, BikshapathiX <bikshapathix.kothapeta@intel.com>