### PR TITLE
[c2][parameter] Fixed hevc testValidateProfileLevel 5 failures

### DIFF
--- a/c2_components/src/mfx_c2_component.cpp
+++ b/c2_components/src/mfx_c2_component.cpp
@@ -210,6 +210,13 @@ c2_status_t MfxC2Component::querySupportedValues_vb(
 
     c2_status_t res = C2_OK;
     res = querySupportedValues(queries, mayBlock);
+    for (C2FieldSupportedValuesQuery &query : queries) {
+        if (C2_OK != query.status) {
+            C2Param::Index ix = _C2ParamInspector::getIndex(query.field());
+            MFX_DEBUG_TRACE_STREAM("param " << ix.typeIndex() << " query failed, status = "
+                                << (int)query.status);
+        }
+    }
     MFX_DEBUG_TRACE__android_c2_status_t(res);
     return res;
 }

--- a/c2_components/src/mfx_c2_encoder_component.cpp
+++ b/c2_components/src/mfx_c2_encoder_component.cpp
@@ -338,7 +338,7 @@ MfxC2EncoderComponent::MfxC2EncoderComponent(const C2String name, const CreateCo
 
             addParameter(DefineParam(m_profileLevel, C2_PARAMKEY_PROFILE_LEVEL)
                 .withDefault(new C2StreamProfileLevelInfo::output(
-                    SINGLE_STREAM_ID, PROFILE_HEVC_MAIN, LEVEL_HEVC_MAIN_5_1))
+                    SINGLE_STREAM_ID, PROFILE_HEVC_MAIN, LEVEL_HEVC_MAIN_6))
                 .withFields({
                     C2F(m_profileLevel, C2ProfileLevelStruct::profile)
                         .oneOf({
@@ -897,8 +897,14 @@ mfxStatus MfxC2EncoderComponent::InitEncoder()
             MFX_DEBUG_TRACE_MSG("Encoder initialized");
             MFX_DEBUG_TRACE__mfxStatus(mfx_res);
 
+            // ignore warnings
             if (MFX_WRN_PARTIAL_ACCELERATION == mfx_res) {
                 MFX_DEBUG_TRACE_MSG("InitEncoder returns MFX_WRN_PARTIAL_ACCELERATION");
+                mfx_res = MFX_ERR_NONE;
+            }
+
+            if (MFX_WRN_INCOMPATIBLE_VIDEO_PARAM == mfx_res) {
+                MFX_DEBUG_TRACE_MSG("InitEncoder returns MFX_WRN_INCOMPATIBLE_VIDEO_PARAM");
                 mfx_res = MFX_ERR_NONE;
             }
 

--- a/c2_store/data/media_codecs_intel_c2_video.xml
+++ b/c2_store/data/media_codecs_intel_c2_video.xml
@@ -18,6 +18,12 @@
 from AOSP frameworks/av/media/libstagefright/data/media_codecs_google_c2_video.xml
 and updated to vendor media codecs.
 -->
+
+<!-- 
+    Max block-count = maxHeight / block-size(height) * maxWidth / block-size(W)
+    Max blocks-per-second = Max block-count * frames-per-second
+-->
+
 <Included>
     <Decoders>
         <MediaCodec name="c2.intel.avc.decoder" type="video/avc">
@@ -25,9 +31,9 @@ and updated to vendor media codecs.
             <Limit name="size" min="64x64" max="4096x4096" />
             <Limit name="alignment" value="2x2" />
             <Limit name="block-size" value="16x16" />
-            <Limit name="block-count" range="1-32768" /> <!-- max 4096x2048 equivalent -->
+            <Limit name="block-count" range="1-65536" /> <!-- max 4096x4096 equivalent -->
             <Limit name="blocks-per-second" range="1-1966080" />
-            <Limit name="bitrate" range="1-48000000" />
+            <Limit name="bitrate" range="1-40000000" />
             <Limit name="performance-point-3840x2160" value="30" />
             <Feature name="adaptive-playback" />
         </MediaCodec>
@@ -36,9 +42,9 @@ and updated to vendor media codecs.
             <Limit name="size" min="64x64" max="8192x8192" />
             <Limit name="alignment" value="2x2" />
             <Limit name="block-size" value="8x8" />
-            <Limit name="block-count" range="1-196608" /> <!-- max 4096x3072 -->
-            <Limit name="blocks-per-second" range="1-2000000" />
-            <Limit name="bitrate" range="1-10000000" />
+            <Limit name="block-count" range="1-1048576" /> <!-- max 8192x8192 -->
+            <Limit name="blocks-per-second" range="1-31457280" />
+            <Limit name="bitrate" range="1-40000000" />
             <Limit name="performance-point-3840x2160" value="30" />
             <Feature name="adaptive-playback" />
         </MediaCodec>
@@ -46,17 +52,17 @@ and updated to vendor media codecs.
             <Limit name="size" min="64x64" max="8192x8192" />
             <Limit name="alignment" value="2x2" />
             <Limit name="block-size" value="16x16" />
-            <Limit name="block-count" range="1-16384" />
-            <Limit name="blocks-per-second" range="1-500000" />
+            <Limit name="block-count" range="1-262144" />
+            <Limit name="blocks-per-second" range="1-7864320" />
             <Limit name="bitrate" range="1-40000000" />
             <Limit name="performance-point-3840x2160" value="30" />
-            <Feature name="adaptive-playback" />
+	    <Feature name="adaptive-playback" />
         </MediaCodec>
         <MediaCodec name="c2.intel.vp8.decoder" type="video/x-vnd.on2.vp8">
             <Limit name="size" min="64x64" max="4096x4096" />
             <Limit name="alignment" value="2x2" />
             <Limit name="block-size" value="16x16" />
-            <Limit name="block-count" range="1-16384" />
+            <Limit name="block-count" range="1-131072" />
             <Limit name="blocks-per-second" range="1-500000" />
             <Limit name="bitrate" range="1-40000000" />
             <Limit name="performance-point-3840x2160" value="30" />


### PR DESCRIPTION
cases:
android.mediav2.cts.EncoderProfileLevelTest#testValidateProfileLevel[26(c2.intel.hevc.encoder_video/hevc)]

1. Ignored the warning which retured by m_mfxEncoder->Init.
2. Reconfigured bitrate and block-count in xml.

Tracked-On: OAM-105728
Signed-off-by: zhangyichix <yichix.zhang@intel.com>
Signed-off-by: Kothapeta, BikshapathiX <bikshapathix.kothapeta@intel.com>