### PR TITLE
Remove the unnecessary check in updating params

### DIFF
--- a/c2_components/src/mfx_c2_encoder_component.cpp
+++ b/c2_components/src/mfx_c2_encoder_component.cpp
@@ -1712,10 +1712,6 @@ void MfxC2EncoderComponent::DoUpdateMfxParam(const std::vector<C2Param*> &params
                 else if (m_encoderType == ENCODER_H265 && framerate_value > MFX_MAX_H265_FRAMERATE) {
                     framerate_value = MFX_MAX_H265_FRAMERATE;
                 }
-                else {
-                    failures->push_back(MakeC2SettingResult(C2ParamField(param), C2SettingResult::BAD_TYPE));
-                    break;
-                }
 
                 m_mfxVideoParamsConfig.mfx.FrameInfo.FrameRateExtN = uint64_t(framerate_value * 1000); // keep 3 sign after dot
                 m_mfxVideoParamsConfig.mfx.FrameInfo.FrameRateExtD = 1000;


### PR DESCRIPTION
Once the type is not H264 or H265, and the params is valid. Just set framerate.

Tracked-On: OAM-105975
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>