### PR TITLE
[c2][encoder] Fixed a dangling reference issue

### DIFF
--- a/c2_components/src/mfx_c2_encoder_component.cpp
+++ b/c2_components/src/mfx_c2_encoder_component.cpp
@@ -1308,8 +1308,10 @@ void MfxC2EncoderComponent::DoWork(std::unique_ptr<C2Work>&& work)
             break;
         }
 
-        m_waitingQueue.Push( [&mfx_frame_in, this ] () mutable {
-            RetainLockedFrame(std::move(mfx_frame_in));
+        // XXX: "Big parameter passed by value(PASS_BY_VALUE)" by Coverity scanning.
+        // mfx_frame of type size 136 bytes.
+        m_waitingQueue.Push( [ mfx_frame = std::move(mfx_frame_in), this ] () mutable {
+            RetainLockedFrame(std::move(mfx_frame));
         } );
 
         m_pendingWorks.push(std::move(work));


### PR DESCRIPTION
For fixing Coverity issue(Big parameter passed by value), we used reference instead of value. But found a dangling reference issue. So revert it.

Tracked-On: OAM-108736