### PR TITLE
Add some color format support for codec2

### DIFF
--- a/c2_components/include/mfx_c2_decoder_component.h
+++ b/c2_components/include/mfx_c2_decoder_component.h
@@ -239,8 +239,6 @@ private:
 
     MfxC2ColorAspectsWrapper m_colorAspectsWrapper;
 
-    std::shared_ptr<C2StreamPixelFormatInfo::output> m_pixelFormat;
-
     std::vector<std::unique_ptr<C2Param>> m_updatingC2Configures;
 
     uint64_t m_consumerUsage;
@@ -281,6 +279,7 @@ private:
     std::shared_ptr<C2StreamColorAspectsTuning::output> m_defaultColorAspects;
     std::shared_ptr<C2StreamColorAspectsInfo::input> m_codedColorAspects;
     std::shared_ptr<C2StreamColorAspectsInfo::output> m_colorAspects;
+    std::shared_ptr<C2StreamPixelFormatInfo::output> m_pixelFormat;
     /* ----------------------------------------Setters------------------------------------------- */
     static C2R OutputSurfaceAllocatorSetter(bool mayBlock, C2P<C2PortSurfaceAllocatorTuning::output> &me);
     static C2R SizeSetter(bool mayBlock, const C2P<C2StreamPictureSizeInfo::output> &oldMe,


### PR DESCRIPTION
case: android.mediav2.cts.CodecDecoderSurfaceTest#
	testSimpleDecodeToSurface[2(c2.intel.av1.decoder_video/av01)]

Some cases will fail due to lack of the 10-bit format advertised for codec2.

Tracked-On: OAM-111178