### PR TITLE
Add getgid and getegid into allow list of seccomp

### DIFF
--- a/c2_store/seccomp_policy/android.hardware.media.c2@1.0-x86.policy
+++ b/c2_store/seccomp_policy/android.hardware.media.c2@1.0-x86.policy
@@ -19,6 +19,8 @@ openat: 1
 open: 1
 getuid32: 1
 getuid: 1
+getgid: 1
+getgid32: 1
 getrlimit: 1
 writev: 1
 ioctl: 1
@@ -69,6 +71,7 @@ getpid: 1
 gettid: 1
 getcwd: 1
 geteuid32: 1
+getegid32: 1
 
 getpgid: 1
 sigkill: 1

--- a/c2_store/seccomp_policy/android.hardware.media.c2@1.0-x86_64.policy
+++ b/c2_store/seccomp_policy/android.hardware.media.c2@1.0-x86_64.policy
@@ -19,6 +19,8 @@ openat: 1
 open: 1
 getuid32: 1
 getuid: 1
+getgid: 1
+getgid32: 1
 getrlimit: 1
 writev: 1
 ioctl: 1
@@ -69,6 +71,7 @@ getpid: 1
 gettid: 1
 getcwd: 1
 geteuid32: 1
+getegid32: 1
 
 getpgid: 1
 sigkill: 1


### PR DESCRIPTION
getgid and getegid are invoked in libva 2.19 release for security_getenv so add them into allow list, otherwise, libva will failed to load driver.

Tracked-On: OAM-111675