### PR TITLE
[c2][encoder] Fixed the gralloc4 not working on Android U

### DIFF
--- a/c2_utils/include/mfx_gralloc1.h
+++ b/c2_utils/include/mfx_gralloc1.h
@@ -39,7 +39,7 @@ public:
     virtual c2_status_t Free(const buffer_handle_t handle);
     virtual c2_status_t LockFrame(buffer_handle_t handle, uint8_t** data, C2PlanarLayout *layout);
     virtual c2_status_t UnlockFrame(buffer_handle_t handle);
-    virtual c2_status_t ImportBuffer(const buffer_handle_t rawHandle, buffer_handle_t *outBuffer);
+    virtual buffer_handle_t ImportBuffer(const buffer_handle_t rawHandle) override;
 
 protected:
     hw_module_t const* m_hwModule {};

--- a/c2_utils/include/mfx_gralloc4.h
+++ b/c2_utils/include/mfx_gralloc4.h
@@ -49,6 +49,7 @@ public:
 
     virtual c2_status_t GetBufferDetails(const buffer_handle_t handle, BufferDetails* details) override;
     virtual c2_status_t GetBackingStore(const buffer_handle_t rawHandle, uint64_t *id) override;
+    virtual buffer_handle_t ImportBuffer(const buffer_handle_t rawHandle) override;
 
     // TODO: not fully tested
     virtual c2_status_t LockFrame(buffer_handle_t handle, uint8_t** data, C2PlanarLayout *layout);

--- a/c2_utils/include/mfx_gralloc_interface.h
+++ b/c2_utils/include/mfx_gralloc_interface.h
@@ -56,5 +56,5 @@ public:
     virtual c2_status_t GetBufferDetails(const buffer_handle_t handle, BufferDetails* details) = 0;
     virtual c2_status_t GetBackingStore(const buffer_handle_t rawHandle, uint64_t *id) = 0;
 
-
+    virtual buffer_handle_t ImportBuffer(const buffer_handle_t rawHandle) = 0;
 };

--- a/c2_utils/src/mfx_gralloc1.cpp
+++ b/c2_utils/src/mfx_gralloc1.cpp
@@ -273,19 +273,21 @@ c2_status_t MfxGralloc1Module::UnlockFrame(buffer_handle_t handle)
     return res;
 }
 
-c2_status_t MfxGralloc1Module::ImportBuffer(const buffer_handle_t rawHandle, buffer_handle_t *outBuffer)
+buffer_handle_t MfxGralloc1Module::ImportBuffer(const buffer_handle_t rawHandle)
 {
     MFX_DEBUG_TRACE_FUNC;
     c2_status_t res = C2_OK;
+    buffer_handle_t *outBuffer = nullptr;
     int32_t gr1_res = (*m_grImportBufferFunc)(m_gralloc1_dev, rawHandle, outBuffer);
 
     if (GRALLOC1_ERROR_NONE != gr1_res) {
         MFX_DEBUG_TRACE_I32(gr1_res);
         res = C2_BAD_STATE;
     }
+    buffer_handle_t out = const_cast<buffer_handle_t>(*outBuffer);
 
     MFX_DEBUG_TRACE__android_c2_status_t(res);
-    return res;
+    return out;
 }
 
 c2_status_t MfxGralloc1Module::GetBackingStore(const buffer_handle_t rawHandle, uint64_t *id)

--- a/c2_utils/src/mfx_gralloc4.cpp
+++ b/c2_utils/src/mfx_gralloc4.cpp
@@ -98,7 +98,7 @@ c2_status_t MfxGralloc4Module::GetBufferDetails(const buffer_handle_t handle, Bu
         uint64_t height = 0;
         gralloc4::decodeHeight(vec, &height);
         details->height = details->allocHeight = height;
-        MFX_DEBUG_TRACE_I32(details->width);
+        MFX_DEBUG_TRACE_I32(details->height);
 
         hardware::graphics::common::V1_2::PixelFormat pixelFormat;
         if (IsFailed(get(handle, gralloc4::MetadataType_PixelFormatRequested, vec)))
@@ -148,6 +148,28 @@ c2_status_t MfxGralloc4Module::GetBackingStore(const buffer_handle_t handle, uin
 
     MFX_DEBUG_TRACE__android_c2_status_t(res);
     return res;
+}
+
+buffer_handle_t MfxGralloc4Module::ImportBuffer(const buffer_handle_t rawHandle)
+{
+    MFX_DEBUG_TRACE_FUNC;
+    c2_status_t res = C2_OK;
+    buffer_handle_t outBuffer = nullptr;
+    Error4 err;
+
+    if (nullptr == m_mapper)
+        res = C2_CORRUPTED;
+    if (C2_OK == res)
+    {
+        m_mapper->importBuffer(hardware::hidl_handle(rawHandle), [&](const Error4 & tmpError, void * tmpBuffer) {
+            err = tmpError;
+            outBuffer = static_cast<buffer_handle_t>(tmpBuffer);
+        });
+        if (IsFailed(err))
+            res = C2_CORRUPTED;
+    }
+    MFX_DEBUG_TRACE__android_c2_status_t(res);
+    return outBuffer;
 }
 
 c2_status_t MfxGralloc4Module::LockFrame(buffer_handle_t handle, uint8_t** data, C2PlanarLayout *layout)

--- a/mfx_c2_defs.mk
+++ b/mfx_c2_defs.mk
@@ -24,6 +24,9 @@ endif
 
 # Android version preference:
 # We start codec2.0 development starting from Android R
+ifneq ($(filter 14 14.% U% ,$(PLATFORM_VERSION)),)
+  MFX_ANDROID_VERSION:= MFX_U
+endif
 ifneq ($(filter 13 13.% T% ,$(PLATFORM_VERSION)),)
   MFX_ANDROID_VERSION:= MFX_T
 endif


### PR DESCRIPTION
From Android U, the get function of IMapper4 will check whether the buffer handle is reserved. So we need to call importBuffer before getting the buffer's info.

https://chromium-review.googlesource.com/c/chromiumos/platform/minigbm/+/3433121

Tracked-On: OAM-111738