### PR TITLE
[c2][decoder] Fixed the ERR_UNDEFINED_BEHAVIOR error in vp9 decoding

### DIFF
--- a/c2_components/src/mfx_c2_decoder_component.cpp
+++ b/c2_components/src/mfx_c2_decoder_component.cpp
@@ -1996,8 +1996,8 @@ void MfxC2DecoderComponent::DoWork(std::unique_ptr<C2Work>&& work)
     bool expect_output = false;
     bool flushing = false;
     bool codecConfig = ((incoming_flags & C2FrameData::FLAG_CODEC_CONFIG) != 0);
-    // Av1 don't need the bs which flag is config.
-    if (codecConfig && DECODER_AV1 == m_decoderType) {
+    // Av1 and VP9 don't need the bs which flag is config.
+    if (codecConfig && (DECODER_AV1 == m_decoderType || DECODER_VP9 == m_decoderType)) {
         FillEmptyWork(std::move(work), C2_OK);
         if (true == m_bInitialized) {
             mfxStatus format_change_sts = HandleFormatChange();


### PR DESCRIPTION
case:testFlushNative[39(c2.intel.vp9.decoder_video/x-vnd.on2.vp9)]

The error comes from onevpl when we get multiple flushing request in decoding. The root is that vp9 don't need process the bs which the flag is config.

Tracked-On: OAM-112305