### PR TITLE
Fixed few static analysis issues<2>

### DIFF
--- a/c2_store/src/mfx_c2_service.cpp
+++ b/c2_store/src/mfx_c2_service.cpp
@@ -106,11 +106,11 @@ int main(int /* argc */, char** /* argv */) {
         android::hardware::configureRpcThreadpool(8, true /* callerWillJoin */);
 
         RegisterC2Service();
+
+        android::hardware::joinRpcThreadpool();
+
     } catch(const std::exception& ex) {
         // ALOGE("hardware.intel.media.c2@1.0-service exception: %s", ex.what());
-        return 0;
     }
-
-    android::hardware::joinRpcThreadpool();
     return 0;
 }

--- a/c2_utils/src/mfx_gralloc1.cpp
+++ b/c2_utils/src/mfx_gralloc1.cpp
@@ -280,7 +280,7 @@ buffer_handle_t MfxGralloc1Module::ImportBuffer(const buffer_handle_t rawHandle)
     buffer_handle_t *outBuffer = nullptr;
     int32_t gr1_res = (*m_grImportBufferFunc)(m_gralloc1_dev, rawHandle, outBuffer);
 
-    if (GRALLOC1_ERROR_NONE != gr1_res) {
+    if (GRALLOC1_ERROR_NONE != gr1_res || nullptr == outBuffer) {
         MFX_DEBUG_TRACE_I32(gr1_res);
         res = C2_BAD_STATE;
     }

--- a/c2_utils/src/mfx_va_frame_pool_allocator.cpp
+++ b/c2_utils/src/mfx_va_frame_pool_allocator.cpp
@@ -25,6 +25,7 @@
 
 #include "mfx_c2_utils.h"
 #include "mfx_debug.h"
+#include "mfx_msdk_debug.h"
 
 #include <C2AllocatorGralloc.h>
 
@@ -155,6 +156,13 @@ mfxStatus MfxVaFramePoolAllocator::AllocFrames(mfxFrameAllocRequest *request,
             }
             MFX_DEBUG_TRACE_I32(response->NumFrameActual);
 
+            if (MFX_ERR_NONE != mfx_res) {
+                MFX_DEBUG_TRACE_MSG("Fatal error occurred while allocating memory");
+
+                MFX_DEBUG_TRACE__mfxStatus(mfx_res);
+                return mfx_res;
+            }
+
             if (response->NumFrameActual >= request->NumFrameMin) {
                 response->mids = mids.release();
                 m_pool = std::make_unique<MfxPool<C2GraphicBlock>>(); //release graphic buffer
@@ -172,6 +180,7 @@ mfxStatus MfxVaFramePoolAllocator::AllocFrames(mfxFrameAllocRequest *request,
         mfx_res = AllocFrames(request, response);
     }
 
+    MFX_DEBUG_TRACE__mfxStatus(mfx_res);
     return mfx_res;
 }
 


### PR DESCRIPTION
    1. Uncaught exception (UNCAUGHT_EXCEPT).
    2. Unchecked return value (CHECKED_RETURN).
    3. Assigning value MFX_ERR_INVALID_HANDLE to mfx_res here, but that stored value is overwritten before it can be used.
    4. Variable c2Handle going out of scope leaks the storage it points to.
    5. Dereferencing null pointer outBuffer.

Tracked-On: OAM-112437