### PR TITLE
libstagefright/foundation/bufferpool/include path changed

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -63,8 +63,8 @@ mfx_cc_defaults {
 
     include_dirs: [
         "hardware/intel/external/minigbm-intel/cros_gralloc", // remove then minigbm gets Android.bp
-        "frameworks/av/media/libstagefright/foundation/include",
-        "frameworks/av/media/bufferpool/2.0/include",
+        "frameworks/av/media/module/foundation/include",
+        "frameworks/av/media/module/bufferpool/2.0/include",
         "frameworks/av/media/codec2/sfplugin/utils",
         "frameworks/av/media/codec2/vndk/include",
         "frameworks/native/include",

--- a/c2_utils/Android.bp
+++ b/c2_utils/Android.bp
@@ -62,7 +62,7 @@ cc_library_static {
         "frameworks/av/media/codec2/components/base/include",
         "frameworks/av/media/codec2/core/include",
         "frameworks/av/media/libstagefright/include",
-        "frameworks/av/media/libstagefright/foundation/include",
+        "frameworks/av/media/module/foundation/include",
         "frameworks/native/libs/gralloc/types/include",
         "system/core/include/utils",
         "external/libdrm/include/drm",


### PR DESCRIPTION
libstagefright/foundation/bufferpool has been moved to module on android U.

Tracked-On: OAM-112807