### PR TITLE
Fix a compilation error caused by a wrong name

### DIFF
--- a/plugin_store/src/mfx_c2_buffer_queue.cpp
+++ b/plugin_store/src/mfx_c2_buffer_queue.cpp
@@ -305,8 +305,8 @@ private:
                 std::shared_ptr<C2GraphicAllocation> alloc;
                 c2_status_t err = mAllocator->priorGraphicAllocation(c2Handle, &alloc);
                 if (err != C2_OK) {
-                    native_handle_close(handle);
-                    native_handle_delete(handle);
+                    native_handle_close(c2Handle);
+                    native_handle_delete(c2Handle);
                     return err;
                 }
                 std::shared_ptr<MfxC2BufferQueueBlockPoolData> poolData =


### PR DESCRIPTION
 * Fix a compilation error caused by a wrong name

Tracked-On: OAM-112950