### PR TITLE
Force to set CQP rate control on dGPU

### DIFF
--- a/c2_components/src/mfx_c2_encoder_component.cpp
+++ b/c2_components/src/mfx_c2_encoder_component.cpp
@@ -1892,6 +1892,10 @@ void MfxC2EncoderComponent::DoUpdateMfxParam(const std::vector<C2Param*> &params
                         break;
                 }
                 MFX_DEBUG_TRACE_STREAM("set m_bitrateMode->value = " << m_bitrateMode->value);
+                if (isdGPU()) {
+                    // dGPU only support CQP
+                    mfx_set_RateControlMethod(MFX_RATECONTROL_CQP, &m_mfxVideoParamsConfig);
+		}
                 if(MFX_ERR_NONE != sts) {
                     failures->push_back(MakeC2SettingResult(C2ParamField(param), C2SettingResult::BAD_VALUE));
                 }


### PR DESCRIPTION
dGPU only support CQP rate-control.
whatever framework set, force to set CQP.

Tracked-On: OAM-113684
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>