### PR TITLE
[c2][store] Add concurrent-instances support and fixed cts failures

### DIFF
--- a/c2_components/include/mfx_c2_component.h
+++ b/c2_components/include/mfx_c2_component.h
@@ -37,6 +37,7 @@ public:
     {
         int flags{0};
         bool dump_output{false};
+        uint32_t concurrent_instances{0};
     };
 protected:
     /* State diagram:

--- a/c2_store/src/mfx_c2_store.cpp
+++ b/c2_store/src/mfx_c2_store.cpp
@@ -314,6 +314,7 @@ c2_status_t MfxC2ComponentStore::readConfigFile()
             MfxC2Component::CreateConfig config;
             config.flags = flags;
             config.dump_output = m_xmlParser.dumpOutputEnabled(name.c_str());
+            config.concurrent_instances = m_xmlParser.getConcurrentInstances(name.c_str());
 
             m_componentsRegistry_.emplace(name, ComponentDesc(module.c_str(), media_type.c_str(), kind, config));
         }

--- a/c2_utils/include/mfx_c2_components_monitor.h
+++ b/c2_utils/include/mfx_c2_components_monitor.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2017-2023 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <string>
+#include <map>
+#include <mutex>
+#include "mfx_defs.h"
+
+class MfxC2ComponentsMonitor
+{
+private:
+    MfxC2ComponentsMonitor() {}
+public:
+    MFX_CLASS_NO_COPY(MfxC2ComponentsMonitor);
+
+    static MfxC2ComponentsMonitor& getInstance()
+    {
+        static MfxC2ComponentsMonitor m_pInstance;
+        return m_pInstance;
+    }
+
+    unsigned int get(std::string name);
+    void increase(std::string name);
+    void decrease(std::string name);
+
+private:
+    std::map<std::string, unsigned int> m_monitor;
+    std::mutex m_mutex;
+};

--- a/c2_utils/include/mfx_c2_xml_parser.h
+++ b/c2_utils/include/mfx_c2_xml_parser.h
@@ -49,6 +49,7 @@ public:
     c2_status_t parseConfig(const char *path);
     C2Component::kind_t getKind(const char *name);
     C2String getMediaType(const char *name);
+    uint32_t getConcurrentInstances(const char *name);
     bool dumpOutputEnabled(const char *name);
 
 private:
@@ -60,6 +61,7 @@ private:
         size_t order;      // order of appearance in the file (starting from 0)
         std::map<C2String, AttributeMap> typeMap;   // map of types supported by this codec
         bool dump_output{false};
+        uint32_t concurrentInstance{0};
     };
 
     enum Section {
@@ -78,6 +80,8 @@ private:
     c2_status_t addMediaCodecFromAttributes(bool encoder, const char **attrs);
 
     c2_status_t addDiagnostics(const char **attrs);
+
+    c2_status_t addLimits(const char **attrs);
 
     void startElementHandler(const char *name, const char **attrs);
     void endElementHandler(const char *name);

--- a/c2_utils/include/mfx_defs.h
+++ b/c2_utils/include/mfx_defs.h
@@ -57,6 +57,8 @@ extern mfxVersion g_required_mfx_version;
     #include <va/va.h>
 #endif // #ifdef LIBVA_SUPPORT
 
+constexpr uint32_t DEFAULT_MAX_INSTANCES = 32;
+
 #define MFX_MAX_PATH 260
 
 #define WIDTH_16K 16384

--- a/c2_utils/src/mfx_c2_components_monitor.cpp
+++ b/c2_utils/src/mfx_c2_components_monitor.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2017-2023 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_c2_components_monitor.h"
+#include "mfx_c2_debug.h"
+
+#undef MFX_DEBUG_MODULE_NAME
+#define MFX_DEBUG_MODULE_NAME "mfx_c2_components_monitor"
+
+uint32_t MfxC2ComponentsMonitor::get(std::string name)
+{
+    MFX_DEBUG_TRACE_FUNC;
+
+    std::unique_lock<std::mutex> lock(m_mutex);
+    auto obj = m_monitor.find(name);
+    if (m_monitor.end() != obj)
+    {
+        MFX_DEBUG_TRACE_I32(obj->second);
+        return obj->second;
+    }
+    return 0;
+}
+
+void MfxC2ComponentsMonitor::increase(std::string name)
+{
+    MFX_DEBUG_TRACE_FUNC;
+
+    std::unique_lock<std::mutex> lock(m_mutex);
+    auto obj = m_monitor.find(name);
+    if (m_monitor.end() == obj)
+    {
+        MFX_DEBUG_TRACE_STREAM("increase " << name << ", instances 0 + 1");
+        m_monitor.insert(std::pair<std::string, uint32_t>(name, 1));
+    }
+    else
+    {
+        MFX_DEBUG_TRACE_STREAM("increase " << name << ", instances " << obj->second << " + 1");
+        obj->second++;
+    }
+}
+
+void MfxC2ComponentsMonitor::decrease(std::string name)
+{
+    MFX_DEBUG_TRACE_FUNC;
+
+    std::unique_lock<std::mutex> lock(m_mutex);
+    auto obj = m_monitor.find(name);
+    if (m_monitor.end() == obj) // impossible
+    {
+        MFX_DEBUG_TRACE_MSG("can't find the record!");
+        m_monitor.insert(std::pair<std::string, uint32_t>(name, 0));
+    }
+    else
+    {
+        MFX_DEBUG_TRACE_STREAM("decrease " << name << ", instances " << obj->second << " - 1");
+        if (0 == obj->second)
+            obj->second = 0;
+        else
+            obj->second--;
+    }
+}


### PR DESCRIPTION
cases:
testLowerPriorityProcessFailsToReclaimResources
testHigherPriorityProcessReclaimsResources

* The default concurrent instances is 32, you can configure it in xml file if you want. 
(e. g. `<Limit name="concurrent-instances" max="16" />`)

Tracked-On: OAM-112660