### PR TITLE
[c2][decoder] Add some color format support for codec2

### DIFF
--- a/c2_components/include/mfx_c2_decoder_component.h
+++ b/c2_components/include/mfx_c2_decoder_component.h
@@ -236,8 +236,6 @@ private:
     std::shared_ptr<C2StreamHdrStaticInfo::output> m_hdrStaticInfo;
     bool m_bSetHdrStatic;
 
-    std::shared_ptr<C2StreamPixelFormatInfo::output> m_pixelFormat;
-
     std::vector<std::unique_ptr<C2Param>> m_updatingC2Configures;
 
     uint64_t m_consumerUsage;
@@ -278,6 +276,7 @@ private:
     std::shared_ptr<C2StreamColorAspectsTuning::output> m_defaultColorAspects;
     std::shared_ptr<C2StreamColorAspectsInfo::input> m_inColorAspects;
     std::shared_ptr<C2StreamColorAspectsInfo::output> m_outColorAspects;
+    std::shared_ptr<C2StreamPixelFormatInfo::output> m_pixelFormat;
     /* ----------------------------------------Setters------------------------------------------- */
     static C2R OutputSurfaceAllocatorSetter(bool mayBlock, C2P<C2PortSurfaceAllocatorTuning::output> &me);
     static C2R SizeSetter(bool mayBlock, const C2P<C2StreamPictureSizeInfo::output> &oldMe,


### PR DESCRIPTION
case: android.mediav2.cts.CodecDecoderSurfaceTest#
	testSimpleDecodeToSurface[2(c2.intel.av1.decoder_video/av01)]

Some cases will fail due to lack of the 10-bit format advertised for codec2.

Tracked-On: OAM-118544