### PR TITLE
[c2][encoder] Change hevc hw codec minimal supported size

### DIFF
--- a/c2_components/src/mfx_c2_encoder_component.cpp
+++ b/c2_components/src/mfx_c2_encoder_component.cpp
@@ -497,8 +497,8 @@ void MfxC2EncoderComponent::getMaxMinResolutionSupported(
             break;
         }
         case ENCODER_H265: {
-            *min_w = 176;
-            *min_h = 144;
+            *min_w = 352;
+            *min_h = 288;
             *max_w = 8192;
             *max_h = 8192;
             break;


### PR DESCRIPTION
case: android.videocodec.cts.VideoEncoderMinMaxTest#
	testMinMaxSupport[63_c2.intel.hevc.encoder_video/
	hevc_0.00mbps_176x144_30fps_maxb-0_vbr_i-dist-0]

Tracked-On: OAM-118627
@TianmiChen Help double confirm the size.