### PR TITLE
[c2][hdr] Remove 10-bit HDR/HDR+ advertised support for framework

### DIFF
--- a/c2_components/src/mfx_c2_decoder_component.cpp
+++ b/c2_components/src/mfx_c2_decoder_component.cpp
@@ -370,8 +370,9 @@ MfxC2DecoderComponent::MfxC2DecoderComponent(const C2String name, const CreateCo
                         .oneOf({
                             PROFILE_VP9_0,
                             PROFILE_VP9_1,
-                            PROFILE_VP9_2,
-                            PROFILE_VP9_3,
+                            // TODO: support 10-bit HDR
+                            // PROFILE_VP9_2,
+                            // PROFILE_VP9_3,
                         }),
                     C2F(m_profileLevel, C2ProfileLevelStruct::level)
                         .oneOf({

--- a/c2_components/src/mfx_c2_encoder_component.cpp
+++ b/c2_components/src/mfx_c2_encoder_component.cpp
@@ -376,8 +376,9 @@ MfxC2EncoderComponent::MfxC2EncoderComponent(const C2String name, const CreateCo
                         .oneOf({
                             PROFILE_VP9_0,
                             PROFILE_VP9_1,
-                            PROFILE_VP9_2,
-                            PROFILE_VP9_3,
+                            // TODO: support 10-bit HDR
+                            // PROFILE_VP9_2,
+                            // PROFILE_VP9_3,
                         }),
                     C2F(m_profileLevel, C2ProfileLevelStruct::level)
                         .oneOf({


### PR DESCRIPTION
case:
testHDRDisplayCapabilities[6_video/x-vnd.on2.vp9_c2.intel.vp9.decoder] testHDRDisplayCapabilities[7_video/x-vnd.on2.vp9_c2.intel.vp9.encoder]

Temporarily remove 10-bit HDR advertised support until we actually support them.

Tracked-On: OAM-118634