### PR TITLE
[c2][decoder] Fixed the issue incorrect data with 10-bit system memory

### DIFF
--- a/c2_utils/src/mfx_c2_utils.cpp
+++ b/c2_utils/src/mfx_c2_utils.cpp
@@ -514,7 +514,7 @@ int MfxFourCCToGralloc(mfxU32 fourcc, bool using_video_memory)
         case MFX_FOURCC_NV12:
             return using_video_memory ? HAL_PIXEL_FORMAT_NV12_Y_TILED_INTEL : HAL_PIXEL_FORMAT_NV12;
         case MFX_FOURCC_P010:
-            return HAL_PIXEL_FORMAT_P010_INTEL;
+            return using_video_memory ? HAL_PIXEL_FORMAT_P010_INTEL : HAL_PIXEL_FORMAT_YCBCR_P010;
         default:
             return 0;
     }


### PR DESCRIPTION
cases:
android.media.decoder.cts.ImageReaderDecoderTest#decodeTest [70_video/hevc_c2.intel.hevc.decoder_144x136_10bit_swirl_image]

Using HAL_PIXEL_FORMAT_YCBCR_P010 instead of HAL_PIXEL_FORMAT_P010_INTEL when using system buffer.

Tracked-On: OAM-118915