### PR TITLE
[encode] Fix CTS fail of max B frames exceed configured number

### DIFF
--- a/c2_components/src/mfx_c2_encoder_component.cpp
+++ b/c2_components/src/mfx_c2_encoder_component.cpp
@@ -849,6 +849,11 @@ void MfxC2EncoderComponent::AttachExtBuffer()
 {
     MFX_DEBUG_TRACE_FUNC;
 
+    if (m_encoderType == ENCODER_H265) {
+        mfxExtCodingOption3* codingOption3 = m_mfxVideoParamsConfig.AddExtBuffer<mfxExtCodingOption3>();
+        codingOption3->GPB = MFX_CODINGOPTION_OFF;
+    }
+
     if (m_encoderType == ENCODER_H264 || m_encoderType == ENCODER_H265) {
         mfxExtCodingOption* codingOption = m_mfxVideoParamsConfig.AddExtBuffer<mfxExtCodingOption>();
         codingOption->NalHrdConformance = MFX_CODINGOPTION_OFF;

--- a/c2_utils/include/mfx_c2_utils.h
+++ b/c2_utils/include/mfx_c2_utils.h
@@ -219,6 +219,9 @@ template<>struct mfx_ext_buffer_id<mfxExtVideoSignalInfo> {
 template<>struct mfx_ext_buffer_id<mfxExtEncoderResetOption> {
     enum {id = MFX_EXTBUFF_ENCODER_RESET_OPTION };
 };
+template<>struct mfx_ext_buffer_id<mfxExtCodingOption3> {
+    enum {id = MFX_EXTBUFF_CODING_OPTION3};
+};
 
 template <typename R>
 struct ExtParamAccessor


### PR DESCRIPTION
Some CTS tests of android.videocodec.cts.VideoEncoderMaxBFrameTest# testMaxBFrameSupport failed with "Number of BFrames in a SubGOP exceeds maximum number of BFrames configured".

Cause is for HEVC encode, in onevpl-intel-gpu mfxExtCodingOption3 ->GPB is set to "on" by default, which makes GPB frames are used instead of P frames. In CTS test, GPB frames are considered B frames.

Solution is for HEVC encode, set mfxExtCodingOption3->GPB to "off" in parameter to use P frames not GPB frames.

Tracked-On: OAM-118626