### PR TITLE
[c2][encoder] Disable VP9 Encoder 10bit support

### DIFF
--- a/c2_components/src/mfx_c2_encoder_component.cpp
+++ b/c2_components/src/mfx_c2_encoder_component.cpp
@@ -440,8 +440,6 @@ MfxC2EncoderComponent::MfxC2EncoderComponent(const C2String name, const CreateCo
                         .oneOf({
                             PROFILE_VP9_0,
                             PROFILE_VP9_1,
-                            PROFILE_VP9_2,
-                            PROFILE_VP9_3,
                         }),
                     C2F(m_profileLevel, C2ProfileLevelStruct::level)
                         .oneOf({


### PR DESCRIPTION
HAL_PIXEL_FORMAT_YCBCR_P010:android.mediav2.cts.CodecEncoderSurfaceTest#testSimpleEncodeFromSurface [210_c2.intel.vp9.encoder_video/x-vnd.on2.vp9_c2.android.vp9.decoder_video/ x-vnd.on2.vp9_512kbps_30fps_surfaceabgr2101010_tonemapno_persistentsurface]

HAL_PIXEL_FORMAT_P010_INTEL:android.mediav2.cts.CodecEncoderSurfaceTest#testSimpleEncodeFromSurface [208_c2.intel.vp9.encoder_video/x-vnd.on2.vp9_c2.intel.vp9.decoder_video/ x-vnd.on2.vp9_512kbps_30fps_surfaceabgr2101010_tonemapno_persistentsurface]

Tracked-On: OAM-118635