### PR TITLE
[c2][encoder] Add p010 format support in encoder component

### DIFF
--- a/c2_buffers/src/mfx_c2_frame_in.cpp
+++ b/c2_buffers/src/mfx_c2_frame_in.cpp
@@ -146,8 +146,17 @@ c2_status_t MfxC2FrameIn::MfxC2LoadSurfaceInSW(C2ConstGraphicBlock& c_graph_bloc
 
     if (IsNV12(*m_c2GraphicView)) {
         mfx_sts = InitMfxFrameSW(buf_pack.ordinal.timestamp.peeku(), buf_pack.ordinal.frameIndex.peeku(),
-            const_cast<uint8_t*>(m_c2GraphicView->data()[0]),
+            const_cast<uint8_t*>(m_c2GraphicView->data()[0]), const_cast<uint8_t*>(m_c2GraphicView->data()[1]),
             width, height, stride, MFX_FOURCC_NV12, m_mfxFrameInfo,
+            m_pMfxFrameSurface);
+        if (MFX_ERR_NONE != mfx_sts) {
+            res = MfxStatusToC2(mfx_sts);
+            return res;
+        }
+    } else if (IsP010(*m_c2GraphicView)) {
+        mfx_sts = InitMfxFrameSW(buf_pack.ordinal.timestamp.peeku(), buf_pack.ordinal.frameIndex.peeku(),
+            const_cast<uint8_t*>(m_c2GraphicView->data()[0]), const_cast<uint8_t*>(m_c2GraphicView->data()[1]),
+            width, height, stride, MFX_FOURCC_P010, m_mfxFrameInfo,
             m_pMfxFrameSurface);
         if (MFX_ERR_NONE != mfx_sts) {
             res = MfxStatusToC2(mfx_sts);
@@ -185,7 +194,7 @@ c2_status_t MfxC2FrameIn::MfxC2LoadSurfaceInSW(C2ConstGraphicBlock& c_graph_bloc
 #endif
 
         mfx_sts = InitMfxFrameSW(buf_pack.ordinal.timestamp.peeku(), buf_pack.ordinal.frameIndex.peeku(),
-                                m_yuvData.get(), width, height, stride, MFX_FOURCC_NV12, m_mfxFrameInfo,
+                                m_yuvData.get(), m_yuvData.get()+y_plane_size, width, height, stride, MFX_FOURCC_NV12, m_mfxFrameInfo,
                                 m_pMfxFrameSurface);
         if (MFX_ERR_NONE != mfx_sts) {
             res = MfxStatusToC2(mfx_sts);

--- a/c2_buffers/src/mfx_c2_frame_out.cpp
+++ b/c2_buffers/src/mfx_c2_frame_out.cpp
@@ -133,6 +133,7 @@ c2_status_t MfxC2FrameOut::Create(std::shared_ptr<C2GraphicBlock> block,
         const uint32_t stride = wrapper->m_c2GraphicView->layout().planes[C2PlanarLayout::PLANE_Y].rowInc;
         InitMfxFrameSW(timestamp, frame_index,
             const_cast<uint8_t*>(wrapper->m_c2GraphicView->data()[0]),
+            const_cast<uint8_t*>(wrapper->m_c2GraphicView->data()[1]),
             block->width(), block->height(), stride, info.FourCC, info,
             mfx_frame.get());
 

--- a/c2_utils/include/mfx_c2_utils.h
+++ b/c2_utils/include/mfx_c2_utils.h
@@ -120,6 +120,8 @@ bool IsI420(const C2GraphicView &view);
 
 bool IsYV12(const C2GraphicView &view);
 
+bool IsP010(const C2GraphicView &view);
+
 void ParseGop(const std::shared_ptr<C2StreamGopTuning::output> gop, 
     uint32_t &syncInterval, uint32_t &iInterval, uint32_t &maxBframes);
 

--- a/c2_utils/include/mfx_defs.h
+++ b/c2_utils/include/mfx_defs.h
@@ -197,7 +197,7 @@ std::vector<T> MakeVector(T&& item)
 
 mfxStatus InitMfxFrameSW(
     uint64_t timestamp, uint64_t frame_index,
-    uint8_t *data,
+    uint8_t *data_Y, uint8_t *data_UV,
     uint32_t width, uint32_t height, uint32_t stride, uint32_t fourcc, const mfxFrameInfo& info, mfxFrameSurface1* mfx_frame);
 
 mfxStatus InitMfxFrameHW(
@@ -205,7 +205,7 @@ mfxStatus InitMfxFrameHW(
     mfxMemId mem_id,
     uint32_t width, uint32_t height, uint32_t fourcc, const mfxFrameInfo& info, mfxFrameSurface1* mfx_frame);
 
-mfxStatus MFXLoadSurfaceSW(uint8_t *data, uint32_t stride, const mfxFrameInfo& input_info, mfxFrameSurface1* srf);
+mfxStatus MFXLoadSurfaceSW(uint8_t *data_Y, uint8_t *data_UV, uint32_t stride, const mfxFrameInfo& input_info, mfxFrameSurface1* srf);
 
 uint32_t MFXGetSurfaceSize(uint32_t FourCC, uint32_t width, uint32_t height);
 uint32_t MFXGetFreeSurfaceIdx(mfxFrameSurface1 *SurfacesPool, uint32_t nPoolSize);

--- a/c2_utils/src/mfx_c2_utils.cpp
+++ b/c2_utils/src/mfx_c2_utils.cpp
@@ -759,6 +759,37 @@ bool IsYV12(const C2GraphicView &view) {
             && layout.planes[layout.PLANE_V].offset == 0);
 }
 
+bool IsP010(const C2GraphicView &view) {
+    const C2PlanarLayout &layout = view.layout();
+        return (layout.numPlanes == 3
+            && layout.type == C2PlanarLayout::TYPE_YUV
+            && layout.planes[layout.PLANE_Y].channel == C2PlaneInfo::CHANNEL_Y
+            && layout.planes[layout.PLANE_Y].allocatedDepth == 16
+            && layout.planes[layout.PLANE_Y].bitDepth == 10
+            && layout.planes[layout.PLANE_Y].rightShift == 6
+            && layout.planes[layout.PLANE_Y].colSampling == 1
+            && layout.planes[layout.PLANE_Y].rowSampling == 1
+            && layout.planes[layout.PLANE_U].channel == C2PlaneInfo::CHANNEL_CB
+            && layout.planes[layout.PLANE_U].allocatedDepth == 16
+            && layout.planes[layout.PLANE_U].bitDepth == 10
+            && layout.planes[layout.PLANE_U].rightShift == 6
+            && layout.planes[layout.PLANE_U].colSampling == 2
+            && layout.planes[layout.PLANE_U].rowSampling == 2
+            && layout.planes[layout.PLANE_V].channel == C2PlaneInfo::CHANNEL_CR
+            && layout.planes[layout.PLANE_V].allocatedDepth == 16
+            && layout.planes[layout.PLANE_V].bitDepth == 10
+            && layout.planes[layout.PLANE_V].rightShift == 6
+            && layout.planes[layout.PLANE_V].colSampling == 2
+            && layout.planes[layout.PLANE_V].rowSampling == 2
+            && layout.rootPlanes == 2
+            && layout.planes[layout.PLANE_U].colInc == 4
+            && layout.planes[layout.PLANE_U].rootIx == layout.PLANE_U
+            && layout.planes[layout.PLANE_U].offset == 0
+            && layout.planes[layout.PLANE_V].colInc == 4
+            && layout.planes[layout.PLANE_V].rootIx == layout.PLANE_U
+            && layout.planes[layout.PLANE_V].offset == 2);
+}
+
 void ParseGop(
         const std::shared_ptr<C2StreamGopTuning::output> gop,
         uint32_t &syncInterval, uint32_t &iInterval, uint32_t &maxBframes) {


### PR DESCRIPTION
The same with https://github.com/projectceladon/MediaSDK_C2/pull/149, Closed and couldn't be reopened(force push)

Format: HAL_PIXEL_FORMAT_YCBCR_P010
android.mediav2.cts.CodecEncoderSurfaceTest#testSimpleEncodeFromSurface [210_c2.intel.vp9.encoder_video/x-vnd.on2.vp9_c2.android.vp9.decoder_video/ x-vnd.on2.vp9_512kbps_30fps_surfaceabgr2101010_tonemapno_persistentsurface]

Format: HAL_PIXEL_FORMAT_P010_INTEL
android.mediav2.cts.CodecEncoderSurfaceTest#testSimpleEncodeFromSurface[ 208_c2.intel.vp9.encoder_video/x-vnd.on2.vp9_c2.intel.vp9.decoder_video/ x-vnd.on2.vp9_512kbps_30fps_surfaceabgr2101010_tonemapno_persistentsurface]

Tracked-On: OAM-120369