### PR TITLE
[c2][decoder] Re-configure csd after flush for AV1 decode

### DIFF
--- a/c2_buffers/include/mfx_c2_bitstream_in.h
+++ b/c2_buffers/include/mfx_c2_bitstream_in.h
@@ -42,6 +42,7 @@ public:
     virtual c2_status_t AppendFrame(const C2FrameData& buf_pack, c2_nsecs_t timeout,
         std::unique_ptr<C2ReadView>* view);
 
+    virtual bool IsInReset();
 protected: // variables
     std::shared_ptr<IMfxC2FrameConstructor> m_frameConstructor;
 

--- a/c2_buffers/src/mfx_c2_bitstream_in.cpp
+++ b/c2_buffers/src/mfx_c2_bitstream_in.cpp
@@ -57,6 +57,13 @@ c2_status_t MfxC2BitstreamIn::Reset()
     return res;
 }
 
+bool MfxC2BitstreamIn::IsInReset()
+{
+    MFX_DEBUG_TRACE_FUNC;
+
+    return m_frameConstructor->IsInReset();
+}
+
 c2_status_t MfxC2BitstreamIn::Unload()
 {
     MFX_DEBUG_TRACE_FUNC;

--- a/c2_components/src/mfx_c2_decoder_component.cpp
+++ b/c2_components/src/mfx_c2_decoder_component.cpp
@@ -1967,6 +1967,15 @@ void MfxC2DecoderComponent::DoWork(std::unique_ptr<C2Work>&& work)
             }
         }
         return;
+    } else if (DECODER_AV1 == m_decoderType && m_c2Bitstream->IsInReset()) {
+        if (true == m_bInitialized) {
+            mfxStatus format_change_sts = HandleFormatChange();
+            MFX_DEBUG_TRACE__mfxStatus(format_change_sts);
+            mfx_sts = format_change_sts;
+            if (MFX_ERR_NONE != mfx_sts) {
+                FreeDecoder();
+            }
+        }
     }
 
     do {

--- a/c2_utils/include/mfx_frame_constructor.h
+++ b/c2_utils/include/mfx_frame_constructor.h
@@ -69,6 +69,8 @@ public:
     virtual mfxPayload* GetSEI(mfxU32 /*type*/) = 0;
     // save current SPS/PPS
     virtual mfxStatus SaveHeaders(std::shared_ptr<mfxBitstream> sps, std::shared_ptr<mfxBitstream> pps, bool is_reset) = 0;
+    // get whether in reset state
+    virtual bool IsInReset() = 0;
 
 protected:
     struct StartCode
@@ -110,6 +112,8 @@ public:
         (void)is_reset;
         return MFX_ERR_NONE;
     }
+    // get whether in reset state
+    virtual bool IsInReset();
 
 protected: // functions
     virtual mfxStatus LoadHeader(const mfxU8* data, mfxU32 size, bool header);
@@ -147,6 +151,7 @@ protected: // data
     mfxU32 m_uBstBufReallocs;
     mfxU32 m_uBstBufCopyBytes;
 
+    bool m_bInReset;
 private:
     MFX_CLASS_NO_COPY(MfxC2FrameConstructor)
 };

--- a/c2_utils/src/mfx_frame_constructor.cpp
+++ b/c2_utils/src/mfx_frame_constructor.cpp
@@ -34,7 +34,8 @@ MfxC2FrameConstructor::MfxC2FrameConstructor():
     m_profile(MFX_PROFILE_UNKNOWN),
     m_bEos(false),
     m_uBstBufReallocs(0),
-    m_uBstBufCopyBytes(0)
+    m_uBstBufCopyBytes(0),
+    m_bInReset(false)
 {
     MFX_DEBUG_TRACE_FUNC;
 
@@ -198,6 +199,10 @@ mfxStatus MfxC2FrameConstructor::Unload()
     MFX_DEBUG_TRACE_FUNC;
     mfxStatus mfx_res = MFX_ERR_NONE;
 
+    if(m_bInReset) {
+        m_bInReset = false;
+    }
+
     mfx_res = BstBufSync();
 
     MFX_DEBUG_TRACE__mfxStatus(mfx_res);
@@ -209,6 +214,8 @@ mfxStatus MfxC2FrameConstructor::Reset()
 {
     MFX_DEBUG_TRACE_FUNC;
     mfxStatus mfx_res = MFX_ERR_NONE;
+
+    m_bInReset = true;
 
     // saving allocating information about internal buffer
     mfxU8* data = m_bstBuf->Data;
@@ -232,6 +239,11 @@ mfxStatus MfxC2FrameConstructor::Reset()
 
     MFX_DEBUG_TRACE__mfxStatus(mfx_res);
     return mfx_res;
+}
+
+bool MfxC2FrameConstructor::IsInReset()
+{
+    return m_bInReset;
 }
 
 mfxStatus MfxC2FrameConstructor::BstBufRealloc(mfxU32 add_size)


### PR DESCRIPTION
CTS test of android.mediav2.cts.CodecDecoderTest#testFlush run failed with "Decoder output is not consistent across runs".

Cause: For AV1 decode, csd info is removed during flush.

Solution: Add csd config in the end of flush function.

Tracked-On: OAM-119036