### PR TITLE
Revert "[c2][encoder] Disable VP9 Encoder 10bit support"

### DIFF
--- a/c2_components/src/mfx_c2_encoder_component.cpp
+++ b/c2_components/src/mfx_c2_encoder_component.cpp
@@ -440,6 +440,8 @@ MfxC2EncoderComponent::MfxC2EncoderComponent(const C2String name, const CreateCo
                         .oneOf({
                             PROFILE_VP9_0,
                             PROFILE_VP9_1,
+                            PROFILE_VP9_2,
+                            PROFILE_VP9_3,
                         }),
                     C2F(m_profileLevel, C2ProfileLevelStruct::level)
                         .oneOf({


### PR DESCRIPTION
This reverts commit 9787058103e452c007fae774c52804eb3f9ae433. We revert this commit because we have to support vp9 10bit to pass some performance test.

Case:
android.mediapc.cts.MultiTranscoderPerfTest#test4kHbd[10_Pair{video/hevc c2.intel.hevc.decoder} _Pair{video/x-vnd.on2.vp9 c2.intel.vp9.encoder}_true]

Tracked-On: OAM-120841