### PR TITLE
[c2][encoder] Fixed VTS falures

### DIFF
--- a/c2_components/src/mfx_c2_encoder_component.cpp
+++ b/c2_components/src/mfx_c2_encoder_component.cpp
@@ -2041,7 +2041,7 @@ c2_status_t MfxC2EncoderComponent::Queue(std::list<std::unique_ptr<C2Work>>* con
     for(auto& work : *items) {
 
         bool eos = (work->input.flags & C2FrameData::FLAG_END_OF_STREAM);
-        bool empty = (work->input.buffers.size() == 0);
+        bool empty = (work->input.buffers.size() == 0) || !work->input.buffers[0];
         MFX_DEBUG_TRACE_STREAM(NAMED(eos) << NAMED(empty));
 
         if (empty) {


### PR DESCRIPTION
cases: NonStdInputs/Codec2ComponentInputTests

Return empty work When encounter null input buffer.

Tracked-On: OAM-119798