### PR TITLE
Enable av1 encoder in c2_components

### DIFF
--- a/c2_components/include/mfx_c2_encoder_component.h
+++ b/c2_components/include/mfx_c2_encoder_component.h
@@ -56,6 +56,7 @@ public:
         ENCODER_H264,
         ENCODER_H265,
         ENCODER_VP9,
+        ENCODER_AV1,
     };
 
 protected:
@@ -244,6 +245,7 @@ private:
                         C2P<C2StreamPictureSizeInfo::input> &me);
     
     static C2R AVC_ProfileLevelSetter(bool mayBlock, C2P<C2StreamProfileLevelInfo::output> &me);
+    static C2R AV1_ProfileLevelSetter(bool mayBlock, C2P<C2StreamProfileLevelInfo::output> &me);
     static C2R HEVC_ProfileLevelSetter(bool mayBlock, C2P<C2StreamProfileLevelInfo::output> &me);
     static C2R VP9_ProfileLevelSetter(bool mayBlock, C2P<C2StreamProfileLevelInfo::output> &me);
 

--- a/c2_store/src/mfx_c2_store.cpp
+++ b/c2_store/src/mfx_c2_store.cpp
@@ -28,6 +28,7 @@
 
 #include <dlfcn.h>
 #include <fstream>
+#include <sys/stat.h>
 
 static const std::string FIELD_SEP = " : ";
 
@@ -272,6 +273,19 @@ c2_status_t MfxC2ComponentStore::readConfigFile()
     config_filename.append(MFX_C2_CONFIG_FILE_PATH);
     config_filename.append("/");
     config_filename.append(MFX_C2_CONFIG_FILE_NAME);
+    if (config_filename.compare(config_filename.size() - 5, 5, ".conf") == 0) {
+        char codecsVariant[PROPERTY_VALUE_MAX] = {'\0'};
+        if(property_get("ro.vendor.media.target_variant_platform", codecsVariant, NULL) > 0 ) {
+            std::string variant_config_file = config_filename;
+            variant_config_file.insert(variant_config_file.size() - 5, codecsVariant);
+            struct stat fileStat;
+            if (stat(variant_config_file.c_str(), &fileStat) == 0 && S_ISREG(fileStat.st_mode)) {
+                config_filename = variant_config_file;
+                MFX_DEBUG_TRACE_STREAM("Changing config_filename to: " << config_filename.c_str());
+            }
+        }
+    }
+
     std::ifstream config_file(config_filename.c_str(), std::ifstream::in);
 
     if (config_file)
@@ -332,7 +346,19 @@ c2_status_t MfxC2ComponentStore::readXmlConfigFile()
     std::string config_filename = MFX_C2_CONFIG_XML_FILE_PATH;
     config_filename.append("/");
     config_filename.append(MFX_C2_CONFIG_XML_FILE_NAME);
-
+    MFX_DEBUG_TRACE_S(config_filename.c_str());
+    if (config_filename.compare(config_filename.size() - 4, 4, ".xml") == 0) {
+        char codecsVariant[PROPERTY_VALUE_MAX] = {'\0'};
+        if(property_get("ro.vendor.media.target_variant_platform", codecsVariant, NULL) > 0 ) {
+            std::string variant_config_file = config_filename;
+            variant_config_file.insert(variant_config_file.size() - 4, codecsVariant);
+            struct stat fileStat;
+            if (stat(variant_config_file.c_str(), &fileStat) == 0 && S_ISREG(fileStat.st_mode)) {
+                config_filename = variant_config_file;
+                MFX_DEBUG_TRACE_STREAM("Changing xml config_filename to: " << config_filename.c_str());
+            }
+        }
+    }
     c2_res = m_xmlParser.parseConfig(config_filename.c_str());
 
     MFX_DEBUG_TRACE__android_c2_status_t(c2_res);

--- a/c2_utils/include/mfx_c2_utils.h
+++ b/c2_utils/include/mfx_c2_utils.h
@@ -86,6 +86,14 @@ std::unique_ptr<T> AllocUniqueString(const Args(&... args), const char *value)
     return res;
 }
 
+bool Av1ProfileAndroidToMfx(C2Config::profile_t android_value, mfxU16* mfx_value);
+
+bool Av1ProfileMfxToAndroid(mfxU16 mfx_value, C2Config::profile_t* android_value);
+
+bool Av1LevelAndroidToMfx(C2Config::level_t android_value, mfxU16* mfx_value);
+
+bool Av1LevelMfxToAndroid(mfxU16 mfx_value, C2Config::level_t* android_value);
+
 bool AvcProfileAndroidToMfx(C2Config::profile_t android_value, mfxU16* mfx_value);
 
 bool AvcProfileMfxToAndroid(mfxU16 mfx_value, C2Config::profile_t* android_value);

--- a/c2_utils/src/mfx_c2_utils.cpp
+++ b/c2_utils/src/mfx_c2_utils.cpp
@@ -405,6 +405,61 @@ static const std::pair<C2Config::profile_t, mfxU16> g_vp9_profiles[] =
     { PROFILE_VP9_3, MFX_PROFILE_VP9_3 }
 };
 
+static const std::pair<C2Config::level_t, mfxU16> g_av1_levels[] =
+{
+    { LEVEL_AV1_2,  MFX_LEVEL_AV1_2 },
+    { LEVEL_AV1_2_1, MFX_LEVEL_AV1_21 },
+    { LEVEL_AV1_2_2, MFX_LEVEL_AV1_22 },
+    { LEVEL_AV1_2_3, MFX_LEVEL_AV1_23 },
+    { LEVEL_AV1_3, MFX_LEVEL_AV1_3 },
+    { LEVEL_AV1_3_1,  MFX_LEVEL_AV1_31 },
+    { LEVEL_AV1_3_2, MFX_LEVEL_AV1_32 },
+    { LEVEL_AV1_3_3, MFX_LEVEL_AV1_33 },
+    { LEVEL_AV1_4,  MFX_LEVEL_AV1_4 },
+    { LEVEL_AV1_4_1, MFX_LEVEL_AV1_41 },
+    { LEVEL_AV1_4_2, MFX_LEVEL_AV1_42 },
+    { LEVEL_AV1_4_3,  MFX_LEVEL_AV1_43 },
+    { LEVEL_AV1_5, MFX_LEVEL_AV1_5 },
+    { LEVEL_AV1_5_1, MFX_LEVEL_AV1_51 },
+    { LEVEL_AV1_5_2,  MFX_LEVEL_AV1_52 },
+    { LEVEL_AV1_5_3, MFX_LEVEL_AV1_53 },
+    { LEVEL_AV1_6, MFX_LEVEL_AV1_6 },
+    { LEVEL_AV1_6_1,  MFX_LEVEL_AV1_61 },
+    { LEVEL_AV1_6_2, MFX_LEVEL_AV1_62 },
+    { LEVEL_AV1_6_3, MFX_LEVEL_AV1_63 },
+    { LEVEL_AV1_7,  MFX_LEVEL_AV1_7 },
+    { LEVEL_AV1_7_1, MFX_LEVEL_AV1_71 },
+    { LEVEL_AV1_7_2, MFX_LEVEL_AV1_72 },
+    { LEVEL_AV1_7_3,  MFX_LEVEL_AV1_73 }
+};
+
+static const std::pair<C2Config::profile_t, mfxU16> g_av1_profiles[] =
+{
+    { PROFILE_AV1_0, MFX_PROFILE_AV1_MAIN },
+    { PROFILE_AV1_1, MFX_PROFILE_AV1_HIGH },
+    { PROFILE_AV1_2, MFX_PROFILE_AV1_PRO }
+};
+
+bool Av1ProfileAndroidToMfx(C2Config::profile_t android_value, mfxU16* mfx_value)
+{
+    return FirstToSecond(g_av1_profiles, android_value, mfx_value);
+}
+
+bool Av1ProfileMfxToAndroid(mfxU16 mfx_value, C2Config::profile_t* android_value)
+{
+    return SecondToFirst(g_av1_profiles, mfx_value, android_value);
+}
+
+bool Av1LevelAndroidToMfx(C2Config::level_t android_value, mfxU16* mfx_value)
+{
+    return FirstToSecond(g_av1_levels, android_value, mfx_value);
+}
+
+bool Av1LevelMfxToAndroid(mfxU16 mfx_value, C2Config::level_t* android_value)
+{
+    return SecondToFirst(g_av1_levels, mfx_value, android_value);
+}
+
 bool AvcProfileAndroidToMfx(C2Config::profile_t android_value, mfxU16* mfx_value)
 {
     return FirstToSecond(g_h264_profiles, android_value, mfx_value);


### PR DESCRIPTION
Changes include:
- Add ENCODER_AV1 type in MfxC2EncoderComponent
- Register it to ComponentsRegistry
- Define profiles and levels for AV1
- Add mapping of profiles and levels between Mfx and Android

Tests Done:
- Ran CtsMediaEncoderTestCases android.media.encoder.cts.VideoEncoderTest

Tracked-On: OAM-121126