### PR TITLE
Revert "Fix CTS issue: Level information expected at least 2 but got 1"

### DIFF
--- a/c2_components/include/mfx_c2_encoder_component.h
+++ b/c2_components/include/mfx_c2_encoder_component.h
@@ -243,11 +243,7 @@ private:
     static C2R SizeSetter(bool mayBlock, const C2P<C2StreamPictureSizeInfo::input> &oldMe,
                         C2P<C2StreamPictureSizeInfo::input> &me);
     
-    static C2R AVC_ProfileLevelSetter(bool mayBlock,
-                                C2P<C2StreamProfileLevelInfo::output> &me,
-                                const C2P<C2StreamPictureSizeInfo::input> &size,
-                                const C2P<C2StreamFrameRateInfo::output> &frameRate,
-                                const C2P<C2StreamBitrateInfo::output> &bitrate);
+    static C2R AVC_ProfileLevelSetter(bool mayBlock, C2P<C2StreamProfileLevelInfo::output> &me);
     static C2R HEVC_ProfileLevelSetter(bool mayBlock, C2P<C2StreamProfileLevelInfo::output> &me);
     static C2R VP9_ProfileLevelSetter(bool mayBlock, C2P<C2StreamProfileLevelInfo::output> &me);
 


### PR DESCRIPTION
This reverts commit 6063a43f241ac01fc7ba5a7a0504b43956124a4a. This commit has caused some CTS tests to fail.

case:android.media.recorder.cts.MediaRecorderTest#testProfileAvcBaselineLevel1

Tracked-On: OAM-119037