### PR TITLE
[c2][encoder] Support 10 bit / HDR encode for HEVC

### DIFF
--- a/c2_components/include/mfx_c2_encoder_component.h
+++ b/c2_components/include/mfx_c2_encoder_component.h
@@ -239,6 +239,8 @@ private:
     std::shared_ptr<C2StreamIntraRefreshTuning::output> m_intraRefresh;
     std::shared_ptr<C2StreamColorAspectsInfo::input> m_colorAspects;
     std::shared_ptr<C2StreamColorAspectsInfo::output> m_codedColorAspects;
+    std::shared_ptr<C2StreamPixelFormatInfo::input> m_pixelFormat;
+
     /* ---------------------------------Setters------------------------------------------- */
     static C2R SizeSetter(bool mayBlock, const C2P<C2StreamPictureSizeInfo::input> &oldMe,
                         C2P<C2StreamPictureSizeInfo::input> &me);

--- a/c2_components/src/mfx_c2_encoder_component.cpp
+++ b/c2_components/src/mfx_c2_encoder_component.cpp
@@ -425,6 +425,20 @@ MfxC2EncoderComponent::MfxC2EncoderComponent(const C2String name, const CreateCo
                         }),})
                 .withSetter(HEVC_ProfileLevelSetter)
                 .build());
+
+            std::vector<uint32_t> supportedPixelFormats = {
+                HAL_PIXEL_FORMAT_YCBCR_420_888,
+                HAL_PIXEL_FORMAT_YCBCR_P010
+            };
+
+            addParameter(
+                DefineParam(m_pixelFormat, C2_PARAMKEY_PIXEL_FORMAT)
+                .withDefault(new C2StreamPixelFormatInfo::input(
+                                    0u, HAL_PIXEL_FORMAT_YCBCR_420_888))
+                .withFields({C2F(m_pixelFormat, value).oneOf(supportedPixelFormats)})
+                .withSetter((Setter<decltype(*m_pixelFormat)>::StrictValueWithNoDeps))
+                .build());
+
             break;
         };
         case ENCODER_VP9: {
@@ -452,6 +466,20 @@ MfxC2EncoderComponent::MfxC2EncoderComponent(const C2String name, const CreateCo
                         }),})
                 .withSetter(VP9_ProfileLevelSetter)
                 .build());
+
+            std::vector<uint32_t> supportedPixelFormats = {
+                HAL_PIXEL_FORMAT_YCBCR_420_888,
+                HAL_PIXEL_FORMAT_YCBCR_P010
+            };
+
+            addParameter(
+                DefineParam(m_pixelFormat, C2_PARAMKEY_PIXEL_FORMAT)
+                .withDefault(new C2StreamPixelFormatInfo::input(
+                                    0u, HAL_PIXEL_FORMAT_YCBCR_420_888))
+                .withFields({C2F(m_pixelFormat, value).oneOf(supportedPixelFormats)})
+                .withSetter((Setter<decltype(*m_pixelFormat)>::StrictValueWithNoDeps))
+                .build());
+
             break;
         };
         default: {

--- a/c2_components/src/mfx_c2_encoder_component.cpp
+++ b/c2_components/src/mfx_c2_encoder_component.cpp
@@ -408,6 +408,7 @@ MfxC2EncoderComponent::MfxC2EncoderComponent(const C2String name, const CreateCo
                         .oneOf({
                             PROFILE_HEVC_MAIN,
                             PROFILE_HEVC_MAIN_STILL,
+                            PROFILE_HEVC_MAIN_10,
                         }),
                     C2F(m_profileLevel, C2ProfileLevelStruct::level)
                         .oneOf({


### PR DESCRIPTION
Add PROFILE_HEVC_MAIN_10 profile for HEVC encoder to support 10 bit / HDR encode.