### PR TITLE
[c2][encoder] Add P010 support in HEVC/VP9 encoder

### DIFF
--- a/c2_components/include/mfx_c2_encoder_component.h
+++ b/c2_components/include/mfx_c2_encoder_component.h
@@ -239,6 +239,8 @@ private:
     std::shared_ptr<C2StreamIntraRefreshTuning::output> m_intraRefresh;
     std::shared_ptr<C2StreamColorAspectsInfo::input> m_colorAspects;
     std::shared_ptr<C2StreamColorAspectsInfo::output> m_codedColorAspects;
+    std::shared_ptr<C2StreamPixelFormatInfo::input> m_pixelFormat;
+
     /* ---------------------------------Setters------------------------------------------- */
     static C2R SizeSetter(bool mayBlock, const C2P<C2StreamPictureSizeInfo::input> &oldMe,
                         C2P<C2StreamPictureSizeInfo::input> &me);

--- a/c2_components/src/mfx_c2_encoder_component.cpp
+++ b/c2_components/src/mfx_c2_encoder_component.cpp
@@ -425,6 +425,15 @@ MfxC2EncoderComponent::MfxC2EncoderComponent(const C2String name, const CreateCo
                         }),})
                 .withSetter(HEVC_ProfileLevelSetter)
                 .build());
+
+            addParameter(
+                DefineParam(m_pixelFormat, C2_PARAMKEY_PIXEL_FORMAT)
+                .withFields({C2F(m_pixelFormat, value)
+                    .oneOf({
+                        HAL_PIXEL_FORMAT_YCBCR_P010,
+                    })})
+                .build());
+
             break;
         };
         case ENCODER_VP9: {
@@ -452,6 +461,15 @@ MfxC2EncoderComponent::MfxC2EncoderComponent(const C2String name, const CreateCo
                         }),})
                 .withSetter(VP9_ProfileLevelSetter)
                 .build());
+
+            addParameter(
+                DefineParam(m_pixelFormat, C2_PARAMKEY_PIXEL_FORMAT)
+                .withFields({C2F(m_pixelFormat, value)
+                    .oneOf({
+                        HAL_PIXEL_FORMAT_YCBCR_P010,
+                    })})
+                .build());
+
             break;
         };
         default: {

--- a/c2_components/src/mfx_c2_encoder_component.cpp
+++ b/c2_components/src/mfx_c2_encoder_component.cpp
@@ -408,6 +408,7 @@ MfxC2EncoderComponent::MfxC2EncoderComponent(const C2String name, const CreateCo
                         .oneOf({
                             PROFILE_HEVC_MAIN,
                             PROFILE_HEVC_MAIN_STILL,
+                            PROFILE_HEVC_MAIN_10,
                         }),
                     C2F(m_profileLevel, C2ProfileLevelStruct::level)
                         .oneOf({


### PR DESCRIPTION
Add P010 support in HEVC/VP9 encoder to avoid cts assumption failure.