### PR TITLE
[c2][decoder] Add HDR static info into output format

### DIFF
--- a/c2_components/include/mfx_c2_decoder_component.h
+++ b/c2_components/include/mfx_c2_decoder_component.h
@@ -292,4 +292,5 @@ private:
     static C2R ColorAspectsSetter(bool mayBlock, C2P<C2StreamColorAspectsInfo::output> &me,
                                 const C2P<C2StreamColorAspectsTuning::output> &def,
                                 const C2P<C2StreamColorAspectsInfo::input> &coded);
+    static C2R HdrStaticInfoSetter(bool mayBlock, C2P<C2StreamHdrStaticInfo::output> &me);
 };


### PR DESCRIPTION
For HEVC decoder, add support for HDR profile, and add HDR static info into output format.

Similar changes are needed for HEVC encoder.
When passed wrong HDR static info in input, the info not updated to correct info as expected. More changes still needed to pass all HDRInfo cts.