### PR TITLE
[c2][gralloc4] Fixed gralloc4 regression on Android U

### DIFF
--- a/c2_components/src/mfx_c2_encoder_component.cpp
+++ b/c2_components/src/mfx_c2_encoder_component.cpp
@@ -1381,23 +1381,11 @@ void MfxC2EncoderComponent::DoWork(std::unique_ptr<C2Work>&& work)
             mfxMemId mem_id = nullptr;
             bool decode_target = false;
             native_handle_t *grallocHandle = android::UnwrapNativeCodec2GrallocHandle(c_graph_block->handle());
-            // From Android U, the get function of IMapper4 will check whether the buffer handle is reserved.
-            // So we need to call importBuffer before getting the buffer's info.
-#if PLATFORM_SDK_VERSION >= 34 && defined(USE_GRALLOC4) // Android 14(U)
-            buffer_handle_t importedHandle = MfxGrallocInstance::getInstance()->ImportBuffer(grallocHandle);
-
-            mfxStatus mfx_sts = frame_converter->ConvertGrallocToVa(importedHandle,
-                                         decode_target, &mem_id);
-
-            native_handle_delete(const_cast<native_handle_t *>(importedHandle));
-            importedHandle = nullptr;
-#else
             mfxStatus mfx_sts = frame_converter->ConvertGrallocToVa(grallocHandle,
                                          decode_target, &mem_id);
 
             native_handle_delete(grallocHandle);
             grallocHandle = nullptr;
-#endif
 
             if (MFX_ERR_NONE != mfx_sts) {
                 res = MfxStatusToC2(mfx_sts);

--- a/c2_utils/include/mfx_defs.h
+++ b/c2_utils/include/mfx_defs.h
@@ -34,7 +34,7 @@
 
 // includes below are to get Intel color formats
 
-// #define HAVE_GRALLOC4 // We use gralloc4 but keep supporting gralloc1
+#define HAVE_GRALLOC4 // We use gralloc4 but keep supporting gralloc1
 
 #ifdef HAVE_GRALLOC4
     #define USE_GRALLOC4

--- a/c2_utils/include/mfx_gralloc1.h
+++ b/c2_utils/include/mfx_gralloc1.h
@@ -38,7 +38,7 @@ public:
     virtual c2_status_t GetBufferDetails(const buffer_handle_t handle, BufferDetails* details) override;
 
     virtual c2_status_t Alloc(const uint16_t width, const uint16_t height, buffer_handle_t* handle);
-    virtual c2_status_t Free(const buffer_handle_t handle);
+    virtual c2_status_t FreeBuffer(const buffer_handle_t handle) override;
     virtual c2_status_t LockFrame(buffer_handle_t handle, uint8_t** data, C2PlanarLayout *layout);
     virtual c2_status_t UnlockFrame(buffer_handle_t handle);
     virtual buffer_handle_t ImportBuffer(const buffer_handle_t rawHandle) override;

--- a/c2_utils/include/mfx_gralloc4.h
+++ b/c2_utils/include/mfx_gralloc4.h
@@ -44,12 +44,18 @@ public:
     virtual ~MfxGralloc4Module();
 
     // Wrapper for IMapper::get
-    virtual Error4 get(const native_handle_t* bufferHandle, const IMapper4::MetadataType& metadataType,
+    virtual Error4 Get(const native_handle_t* bufferHandle, const IMapper4::MetadataType& metadataType,
+                    hidl_vec<uint8_t>& outVec);
+    virtual Error4 GetWithImported(const native_handle_t* handle, const IMapper4::MetadataType& metadataType,
                     hidl_vec<uint8_t>& outVec);
 
     virtual c2_status_t GetBufferDetails(const buffer_handle_t handle, BufferDetails* details) override;
     virtual c2_status_t GetBackingStore(const buffer_handle_t rawHandle, uint64_t *id) override;
+
+    // Start with Android U, the get function of IMapper4 will check whether the buffer handle is reserved.
+    // So we need to call importBuffer to preserve handle before getting the buffer's info.
     virtual buffer_handle_t ImportBuffer(const buffer_handle_t rawHandle) override;
+    virtual c2_status_t FreeBuffer(const buffer_handle_t rawHandle) override;
 
     // TODO: not fully tested
     virtual c2_status_t LockFrame(buffer_handle_t handle, uint8_t** data, C2PlanarLayout *layout);

--- a/c2_utils/include/mfx_gralloc_interface.h
+++ b/c2_utils/include/mfx_gralloc_interface.h
@@ -57,4 +57,5 @@ public:
     virtual c2_status_t GetBackingStore(const buffer_handle_t rawHandle, uint64_t *id) = 0;
 
     virtual buffer_handle_t ImportBuffer(const buffer_handle_t rawHandle) = 0;
+    virtual c2_status_t FreeBuffer(const buffer_handle_t rawHandle) = 0;
 };

--- a/c2_utils/src/mfx_gralloc1.cpp
+++ b/c2_utils/src/mfx_gralloc1.cpp
@@ -190,7 +190,7 @@ c2_status_t MfxGralloc1Module::Alloc(const uint16_t width, const uint16_t height
     return res;
 }
 
-c2_status_t MfxGralloc1Module::Free(const buffer_handle_t handle)
+c2_status_t MfxGralloc1Module::FreeBuffer(const buffer_handle_t handle)
 {
     MFX_DEBUG_TRACE_FUNC;
     c2_status_t res = C2_OK;

--- a/c2_utils/src/mfx_gralloc4.cpp
+++ b/c2_utils/src/mfx_gralloc4.cpp
@@ -51,7 +51,7 @@ MfxGralloc4Module::~MfxGralloc4Module()
 
 }
 
-Error4 MfxGralloc4Module::get(const native_handle_t* handle, const IMapper4::MetadataType& metadataType,
+Error4 MfxGralloc4Module::Get(const native_handle_t* handle, const IMapper4::MetadataType& metadataType,
                     hidl_vec<uint8_t>& outVec)
 {
     Error4 err;
@@ -66,13 +66,34 @@ Error4 MfxGralloc4Module::get(const native_handle_t* handle, const IMapper4::Met
     return err;
 }
 
+Error4 MfxGralloc4Module::GetWithImported(const native_handle_t* handle, const IMapper4::MetadataType& metadataType,
+                    hidl_vec<uint8_t>& outVec)
+{
+    Error4 err;
+    if (nullptr == m_mapper)
+        return Error4::NO_RESOURCES;
+
+    auto importedHnd = ImportBuffer(handle);
+    m_mapper->get(const_cast<native_handle_t*>(importedHnd), metadataType,
+                [&](const auto& tmpError, const hidl_vec<uint8_t>& tmpVec)
+                {
+                    err = tmpError;
+                    outVec = tmpVec;
+                });
+
+    (void)FreeBuffer(importedHnd);
+    return err;
+}
+
 c2_status_t MfxGralloc4Module::GetBufferDetails(const buffer_handle_t handle, BufferDetails *details)
 {
     MFX_DEBUG_TRACE_FUNC;
     c2_status_t res = C2_OK;
 
+    buffer_handle_t importedHnd = nullptr;
     do
     {
+        importedHnd = ImportBuffer(handle);
         details->handle = handle;
 
         details->prime = handle->data[0];
@@ -80,7 +101,7 @@ c2_status_t MfxGralloc4Module::GetBufferDetails(const buffer_handle_t handle, Bu
 
         hidl_vec<uint8_t> vec;
 
-        if (IsFailed(get(handle, gralloc4::MetadataType_Width, vec)))
+        if (IsFailed(Get(importedHnd, gralloc4::MetadataType_Width, vec)))
         {
             res = C2_CORRUPTED;
             break;
@@ -91,7 +112,7 @@ c2_status_t MfxGralloc4Module::GetBufferDetails(const buffer_handle_t handle, Bu
         details->width = details->allocWidth = width;
         MFX_DEBUG_TRACE_I32(details->width);
 
-        if (IsFailed(get(handle, gralloc4::MetadataType_Height, vec)))
+        if (IsFailed(Get(importedHnd, gralloc4::MetadataType_Height, vec)))
         {
             res = C2_CORRUPTED;
             break;
@@ -103,7 +124,7 @@ c2_status_t MfxGralloc4Module::GetBufferDetails(const buffer_handle_t handle, Bu
         MFX_DEBUG_TRACE_I32(details->height);
 
         hardware::graphics::common::V1_2::PixelFormat pixelFormat;
-        if (IsFailed(get(handle, gralloc4::MetadataType_PixelFormatRequested, vec)))
+        if (IsFailed(Get(importedHnd, gralloc4::MetadataType_PixelFormatRequested, vec)))
         {
             res = C2_CORRUPTED;
             break;
@@ -112,7 +133,7 @@ c2_status_t MfxGralloc4Module::GetBufferDetails(const buffer_handle_t handle, Bu
         details->format = static_cast<int>(pixelFormat);
         MFX_DEBUG_TRACE_I32(details->format);
 
-        if(IsFailed(get(handle, gralloc4::MetadataType_PlaneLayouts, vec)))
+        if(IsFailed(Get(importedHnd, gralloc4::MetadataType_PlaneLayouts, vec)))
         {
             res = C2_CORRUPTED;
             break;
@@ -134,6 +155,8 @@ c2_status_t MfxGralloc4Module::GetBufferDetails(const buffer_handle_t handle, Bu
             MFX_DEBUG_TRACE_STREAM("details->pitches[" << i << "] = " << details->pitches[i]);
         }
     } while (false);
+
+    (void)FreeBuffer(importedHnd);
     MFX_DEBUG_TRACE__android_c2_status_t(res);
     return res;
 }
@@ -144,7 +167,7 @@ c2_status_t MfxGralloc4Module::GetBackingStore(const buffer_handle_t handle, uin
     c2_status_t res = C2_OK;
 
     hidl_vec<uint8_t> vec;
-    if(IsFailed(get(handle, android::gralloc4::MetadataType_BufferId, vec)))
+    if(IsFailed(GetWithImported(handle, android::gralloc4::MetadataType_BufferId, vec)))
         res = C2_CORRUPTED;
     gralloc4::decodeBufferId(vec, id);
 
@@ -172,6 +195,25 @@ buffer_handle_t MfxGralloc4Module::ImportBuffer(const buffer_handle_t rawHandle)
     }
     MFX_DEBUG_TRACE__android_c2_status_t(res);
     return outBuffer;
+}
+
+c2_status_t MfxGralloc4Module::FreeBuffer(const buffer_handle_t rawHandle)
+{
+    MFX_DEBUG_TRACE_FUNC;
+    c2_status_t res = C2_OK;
+    Error4 err;
+    if (nullptr == m_mapper)
+        res = C2_CORRUPTED;
+    if (C2_OK == res)
+    {
+        err = m_mapper->freeBuffer(const_cast<native_handle_t*>(rawHandle));
+
+        if (IsFailed(err))
+            res = C2_CORRUPTED;
+    }
+
+    MFX_DEBUG_TRACE__android_c2_status_t(res);
+    return res;
 }
 
 c2_status_t MfxGralloc4Module::LockFrame(buffer_handle_t handle, uint8_t** data, C2PlanarLayout *layout)


### PR DESCRIPTION
Start with Android U, the get function of IMapper4 will check whether the buffer handle is reserved.
 
1. Call importBuffer to preserve handle before getting the buffer's info.
2. Call freeBuffer at the end.
3. Switch to use gralloc4.

Tracked-On: OAM-112928