### PR TITLE
Resolve Widevine L3 cencSchemeTypeV18 failed

### DIFF
--- a/c2_components/include/mfx_c2_decoder_component.h
+++ b/c2_components/include/mfx_c2_decoder_component.h
@@ -219,7 +219,7 @@ private:
     std::list<MfxC2FrameOut> m_lockedSurfaces; // allocated, but cannot be re-used as Locked by Decoder
 
     std::mutex m_pendingWorksMutex;
-    std::map<decltype(C2WorkOrdinalStruct::timestamp), std::unique_ptr<C2Work>> m_pendingWorks;
+    std::map<decltype(C2WorkOrdinalStruct::frameIndex), std::unique_ptr<C2Work>> m_pendingWorks;
 
     std::shared_ptr<MfxFramePoolAllocator> m_allocator; // used when Video memory output
     // for pre-allocation when Video memory is chosen and always when System memory output


### PR DESCRIPTION
run ats -a x86_6 -m GtsExoPlayerTestCases -t
  com.google.android.exoplayer.gts.CommonEncryptionDrmTest#cencSchemeTypeV184

The root cause is that the resolution changed processing flow was triggered when decoding the last input bitstream with the same timestamp but different frame index. At this point, the input must be processed as an independent frame.

Tracked-On: OAM-118988