### PR TITLE
[c2][coverity] Fix coverity issue CID 349680

### DIFF
--- a/c2_utils/src/mfx_frame_constructor.cpp
+++ b/c2_utils/src/mfx_frame_constructor.cpp
@@ -417,7 +417,6 @@ mfxStatus MfxC2AVCFrameConstructor::FindHeaders(const mfxU8* data, mfxU32 size, 
             start_code = ReadStartCode(&data, &size);
             if (isSPS(start_code.type)) {
                 std::shared_ptr<mfxBitstream> sps = std::make_shared<mfxBitstream>();
-                if (!sps) return MFX_ERR_MEMORY_ALLOC;
 
                 MFX_ZERO_MEMORY((*sps));
                 sps->Data = (mfxU8*)data - start_code.size;


### PR DESCRIPTION
std::make_shared will throw the std::bad_alloc exception rather than return nullptr. 
Here just remove the logically dead code for the coverity issue.

Tracked-On: OAM-123225