### PR TITLE
Add dump functions for encoder/decoder

### DIFF
--- a/c2_buffers/src/mfx_c2_frame_in.cpp
+++ b/c2_buffers/src/mfx_c2_frame_in.cpp
@@ -187,12 +187,6 @@ c2_status_t MfxC2FrameIn::MfxC2LoadSurfaceInSW(C2ConstGraphicBlock& c_graph_bloc
             }
         }
 
-#if MFX_DEBUG_DUMP_FRAME == MFX_DEBUG_YES
-        static int frameIndex = 0;
-        static YUVWriter writer("/data/local/tmp",std::vector<std::string>({}),"encoder_frame.log");
-        writer.Write(m_yuvData.get(), stride, height, frameIndex++);
-#endif
-
         mfx_sts = InitMfxFrameSW(buf_pack.ordinal.timestamp.peeku(), buf_pack.ordinal.frameIndex.peeku(),
                                 m_yuvData.get(), m_yuvData.get()+y_plane_size, width, height, stride, MFX_FOURCC_NV12, m_mfxFrameInfo,
                                 m_pMfxFrameSurface);

--- a/c2_components/include/mfx_c2_component.h
+++ b/c2_components/include/mfx_c2_component.h
@@ -36,7 +36,6 @@ public:
     struct CreateConfig
     {
         int flags{0};
-        bool dump_output{false};
         uint32_t concurrent_instances{0};
         bool low_power_mode{false};
     };

--- a/c2_components/include/mfx_c2_decoder_component.h
+++ b/c2_components/include/mfx_c2_decoder_component.h
@@ -29,6 +29,7 @@
 #include "mfx_frame_pool_allocator.h"
 #include "mfx_gralloc_instance.h"
 #include "mfx_c2_setters.h"
+#include "mfx_c2_utils.h"
 #include <cutils/properties.h>
 
 class MfxC2DecoderComponent : public MfxC2Component
@@ -251,6 +252,18 @@ private:
 
     MFXVideoVPP* m_vpp;
     bool m_vppConversion = false;
+
+    std::unique_ptr<BinaryWriter> m_outputWriter;
+    std::unique_ptr<BinaryWriter> m_inputWriter;
+
+    std::mutex m_dump_output_lock;
+    std::mutex m_dump_input_lock;
+
+    uint32_t m_dump_count = 0;
+    // decoder output dump file number, during decoding one bitstream, if
+    // dump output multiple times, the first dumped file named xxx_0.yuv,
+    // second dumped file named xxx_1.yuv ...
+    uint32_t m_file_num = 0;
 
     /* -----------------------C2Parameters--------------------------- */
     std::shared_ptr<C2ComponentNameSetting> m_name;

--- a/c2_components/include/mfx_c2_decoder_component.h
+++ b/c2_components/include/mfx_c2_decoder_component.h
@@ -252,12 +252,6 @@ private:
     MFXVideoVPP* m_vpp;
     bool m_vppConversion = false;
 
-#if MFX_DEBUG_DUMP_FRAME == MFX_DEBUG_YES
-    int m_count = 0;
-    std::mutex m_count_lock;
-    bool NeedDumpBuffer();
-#endif
-
     /* -----------------------C2Parameters--------------------------- */
     std::shared_ptr<C2ComponentNameSetting> m_name;
     std::shared_ptr<C2ComponentKindSetting> m_kind;

--- a/c2_components/include/mfx_c2_encoder_component.h
+++ b/c2_components/include/mfx_c2_encoder_component.h
@@ -29,6 +29,7 @@
 #include "mfx_c2_utils.h"
 #include "mfx_c2_vpp_wrapp.h"
 #include "mfx_c2_setters.h"
+#include <cutils/properties.h>
 
 // Assumes all calls are done from one (working) thread, no sync is needed.
 // m_ctrlOnce accumulates subsequent changes for one next frame.
@@ -202,8 +203,6 @@ private:
 
     std::shared_ptr<C2BlockPool> m_c2Allocator;
 
-    std::unique_ptr<BinaryWriter> m_outputWriter;
-
     bool m_bHeaderSent{false};
 
     mfxFrameSurface1 *m_encSrfPool;
@@ -219,6 +218,15 @@ private:
 
     // Input frame info with width or height not 16byte aligned
     mfxFrameInfo m_mfxInputInfo;
+
+    std::unique_ptr<BinaryWriter> m_outputWriter;
+    std::unique_ptr<BinaryWriter> m_inputWriter;
+
+    std::mutex m_dump_output_lock;
+    std::mutex m_dump_input_lock;
+
+    uint32_t m_dump_count = 0;
+    uint32_t m_dump_frames_number = 0; //total frames to dump
 
     /* -----------------------C2Parameters--------------------------- */
     std::mutex m_c2ParameterMutex;

--- a/c2_components/src/mfx_c2_decoder_component.cpp
+++ b/c2_components/src/mfx_c2_decoder_component.cpp
@@ -2266,42 +2266,6 @@ void MfxC2DecoderComponent::Drain(std::unique_ptr<C2Work>&& work)
     }
 }
 
-#if MFX_DEBUG_DUMP_FRAME == MFX_DEBUG_YES
-bool MfxC2DecoderComponent::NeedDumpBuffer() {
-    MFX_DEBUG_TRACE_FUNC;
-    const char* key = "mediacodec2.dump.buffer";
-    char* value = new char[20];
-    int len = property_get(key, value, "0");
-
-#include <iostream>
-#include <sstream>
-
-    std::stringstream strValue;
-    strValue << value;
-
-    unsigned int m_frame_number = 0;
-    strValue >> m_frame_number;
-
-    m_count_lock.lock();
-    if (m_count) {
-        delete[] value;
-        m_count_lock.unlock();
-        return true;
-    } else {
-        delete[] value;
-        if (len > 0 && m_frame_number > 0) {
-            m_count = m_frame_number;
-            MFX_DEBUG_TRACE_PRINTF("--------triggered to dump %d buffers---------", m_frame_number);
-            property_set(key, "0");
-            m_count_lock.unlock();
-            return true;
-        }
-        m_count_lock.unlock();
-        return false;
-    }
-}
-#endif
-
 void MfxC2DecoderComponent::WaitWork(MfxC2FrameOut&& frame_out, mfxSyncPoint sync_point)
 {
     MFX_DEBUG_TRACE_FUNC;
@@ -2460,39 +2424,6 @@ void MfxC2DecoderComponent::WaitWork(MfxC2FrameOut&& frame_out, mfxSyncPoint syn
             }
             m_updatingC2Configures.clear();
 
-#if MFX_DEBUG_DUMP_FRAME == MFX_DEBUG_YES
-	    static FILE* m_f = 0;
-            if (NeedDumpBuffer()) {
-                const C2GraphicView& output_view = block->map().get();
-                m_count_lock.lock();
-                if (m_count) {
-                    const uint8_t* srcY = output_view.data()[C2PlanarLayout::PLANE_Y];
-                    const uint8_t* srcU = output_view.data()[C2PlanarLayout::PLANE_U];
-                    const uint8_t* srcV = output_view.data()[C2PlanarLayout::PLANE_V];
-                    if (!m_f) {
-                        m_f = fopen("/data/local/traces/decoder_frame.yuv", "w+");
-                        MFX_DEBUG_TRACE_STREAM("/data/local/traces/decoder_frame.yuv: create:" << m_f);
-		    }
-		    if (m_f) {
-                        size_t copied_Y = 0, copied_U = 0;
-                        copied_Y = fwrite(srcY, mfx_surface->Data.PitchLow * m_mfxVideoParams.mfx.FrameInfo.CropH, 1, m_f);
-                        copied_U = fwrite(srcU, mfx_surface->Data.PitchLow * m_mfxVideoParams.mfx.FrameInfo.CropH / 2, 1, m_f);
-                        MFX_DEBUG_TRACE_PRINTF("############# dumping #%d decoded buffer in size: %dx%d, Y:%zu, U:%zu #################",
-					m_count, mfx_surface->Data.PitchLow, m_mfxVideoParams.mfx.FrameInfo.CropH, copied_Y, copied_U);
-                        if (copied_Y > 0 || copied_U > 0)
-                            m_count--;
-                     }
-                }
-                m_count_lock.unlock();
-            }
-            m_count_lock.lock();
-            if (m_count == 0 && m_f) {
-                fclose(m_f);
-                MFX_DEBUG_TRACE_MSG("dump file is closed");
-                m_f = NULL;
-            }
-            m_count_lock.unlock();
-#endif
             worklet->output.buffers.push_back(out_buffer);
             block = nullptr;
         }

--- a/c2_store/seccomp_policy/android.hardware.media.c2@1.0-arm.policy
+++ b/c2_store/seccomp_policy/android.hardware.media.c2@1.0-arm.policy
@@ -64,6 +64,7 @@ restart_syscall: 1
 rt_sigreturn: 1
 getrandom: 1
 madvise: 1
+mkdirat: 1
 
 # crash dump policy additions
 sigreturn: 1

--- a/c2_store/seccomp_policy/android.hardware.media.c2@1.0-arm64.policy
+++ b/c2_store/seccomp_policy/android.hardware.media.c2@1.0-arm64.policy
@@ -60,6 +60,7 @@ restart_syscall: 1
 rt_sigreturn: 1
 getrandom: 1
 madvise: 1
+mkdirat: 1
 
 # crash dump policy additions
 clock_gettime: 1

--- a/c2_store/seccomp_policy/android.hardware.media.c2@1.0-x86.policy
+++ b/c2_store/seccomp_policy/android.hardware.media.c2@1.0-x86.policy
@@ -63,6 +63,7 @@ uname: 1
 memfd_create: 1
 ftruncate: 1
 ftruncate64: 1
+mkdirat: 1
 
 # Required by AddressSanitizer
 gettid: 1

--- a/c2_store/seccomp_policy/android.hardware.media.c2@1.0-x86_64.policy
+++ b/c2_store/seccomp_policy/android.hardware.media.c2@1.0-x86_64.policy
@@ -63,6 +63,7 @@ uname: 1
 memfd_create: 1
 ftruncate: 1
 ftruncate64: 1
+mkdirat: 1
 
 # Required by AddressSanitizer
 gettid: 1

--- a/c2_store/src/mfx_c2_store.cpp
+++ b/c2_store/src/mfx_c2_store.cpp
@@ -327,7 +327,6 @@ c2_status_t MfxC2ComponentStore::readConfigFile()
 
             MfxC2Component::CreateConfig config;
             config.flags = flags;
-            config.dump_output = m_xmlParser.dumpOutputEnabled(name.c_str());
             config.concurrent_instances = m_xmlParser.getConcurrentInstances(name.c_str());
             config.low_power_mode = m_xmlParser.getLowPowerMode(name.c_str());
 

--- a/c2_utils/include/mfx_c2_defs.h
+++ b/c2_utils/include/mfx_c2_defs.h
@@ -34,8 +34,20 @@
 #define MFX_C2_CONFIG_XML_FILE_NAME "media_codecs_intel_c2_video.xml"
 #define MFX_C2_CONFIG_XML_FILE_PATH "/vendor/etc"
 
-#define MFX_C2_DUMP_DIR "/data/local/tmp"
-#define MFX_C2_DUMP_OUTPUT_SUB_DIR "c2-output"
+#define MFX_C2_DUMP_DIR "/data/local/traces"
+#define MFX_C2_DUMP_DECODER_SUB_DIR "c2-intel-decoder"
+#define MFX_C2_DUMP_ENCODER_SUB_DIR "c2-intel-encoder"
+#define MFX_C2_DUMP_OUTPUT_SUB_DIR "output"
+#define MFX_C2_DUMP_INPUT_SUB_DIR "input"
+
+// dump when dump frames number > 0
+#define DECODER_DUMP_OUTPUT_KEY "c2.decoder.dump.output.number"
+// dump when property set to true
+#define DECODER_DUMP_INPUT_KEY "c2.decoder.dump.input"
+// dump when property set to true
+#define ENCODER_DUMP_OUTPUT_KEY "c2.encoder.dump.output"
+// dump when dump frames number > 0
+#define ENCODER_DUMP_INPUT_KEY "c2.encoder.dump.input.number"
 
 const c2_nsecs_t MFX_SECOND_NS = 1000000000; // 1e9
 

--- a/c2_utils/include/mfx_c2_utils.h
+++ b/c2_utils/include/mfx_c2_utils.h
@@ -187,9 +187,18 @@ public:
         stream_.write((const char*)data, length);
     }
 
+    bool IsOpen()
+    {
+        return stream_.is_open();
+    }
+
+    void Close()
+    {
+        stream_.close();
+    }
+
 private:
     std::ofstream stream_;
-    std::mutex m_mutex;
 };
 
 // Writes YUV format frame to file.It useful for debug.

--- a/c2_utils/include/mfx_c2_xml_parser.h
+++ b/c2_utils/include/mfx_c2_xml_parser.h
@@ -50,7 +50,6 @@ public:
     C2Component::kind_t getKind(const char *name);
     C2String getMediaType(const char *name);
     uint32_t getConcurrentInstances(const char *name);
-    bool dumpOutputEnabled(const char *name);
     bool getLowPowerMode(const char *name);
 
 private:
@@ -61,7 +60,6 @@ private:
         bool isEncoder;    // whether this codec is an encoder or a decoder
         size_t order;      // order of appearance in the file (starting from 0)
         std::map<C2String, AttributeMap> typeMap;   // map of types supported by this codec
-        bool dump_output{false};
         uint32_t concurrentInstance{0};
         bool lowPowerMode{false};
     };

--- a/c2_utils/include/mfx_debug.h
+++ b/c2_utils/include/mfx_debug.h
@@ -26,7 +26,6 @@
 #define MFX_DEBUG MFX_DEBUG_NO // enables DEBUG output
 #define MFX_PERF MFX_DEBUG_NO // enables PERF output, doesn't depends on MFX_DEBUG
 #define MFX_ATRACE MFX_DEBUG_NO // enables systrace
-#define MFX_DEBUG_DUMP_FRAME MFX_DEBUG_NO // enables write frame to file
 
 #define MFX_DEBUG_FILE MFX_DEBUG_NO // sends DEBUG and PERF output to file, otherwise to logcat
 

--- a/c2_utils/src/mfx_c2_utils.cpp
+++ b/c2_utils/src/mfx_c2_utils.cpp
@@ -689,8 +689,6 @@ BinaryWriter::BinaryWriter(const std::string& dir,
     std::stringstream full_name;
     full_name << dir << "/";
 
-    std::lock_guard<std::mutex> lock(m_mutex);
-
     for(const std::string& sub_dir : sub_dirs) {
         full_name << sub_dir;
 

--- a/c2_utils/src/mfx_c2_xml_parser.cpp
+++ b/c2_utils/src/mfx_c2_xml_parser.cpp
@@ -94,18 +94,6 @@ uint32_t  MfxXmlParser::getConcurrentInstances(const char *name) {
     return codec->second.concurrentInstance;
 }
 
-bool MfxXmlParser::dumpOutputEnabled(const char *name) {
-
-    MFX_DEBUG_TRACE_FUNC;
-
-    auto codec = m_codecMap.find(name);
-    if (codec == m_codecMap.end()) {
-        MFX_DEBUG_TRACE_STREAM("codec " << name << "wasn't found");
-        return false;
-    }
-    return codec->second.dump_output;
-}
-
 bool MfxXmlParser::getLowPowerMode(const char *name) {
 
     MFX_DEBUG_TRACE_FUNC;
@@ -190,20 +178,12 @@ c2_status_t MfxXmlParser::addLimits(const char **attrs) {
                 MFX_DEBUG_TRACE_MSG("concurrent-instances is null");
                 return C2_BAD_VALUE;
             }
-        } else if (strcmp(attrs[i], "dumpOutput") == 0) {
-            if (strcmp(attrs[++i], "value") == 0) {
-                m_currentCodec->second.dump_output = parseBoolean(attrs[++i]);
-                MFX_DEBUG_TRACE_PRINTF("m_currentCodec->second.dump_output = %d", m_currentCodec->second.dump_output);
-            } else {
-                MFX_DEBUG_TRACE_MSG("dumpOutput is null");
-                return C2_BAD_VALUE;
-            }
-        } else if (strcmp(attrs[i], "lowPowerMode") == 0) {
+        } else if (strcmp(attrs[i], "low-power-mode") == 0) {
             if (strcmp(attrs[++i], "value") == 0) {
                 m_currentCodec->second.lowPowerMode = parseBoolean(attrs[++i]);
                 MFX_DEBUG_TRACE_PRINTF("m_currentCodec->second.lowPowerMode = %d ", m_currentCodec->second.lowPowerMode);
             } else {
-                MFX_DEBUG_TRACE_MSG("lowPowerMode is null");
+                MFX_DEBUG_TRACE_MSG("low-power-mode is null");
                 return C2_BAD_VALUE;
             }
         }


### PR DESCRIPTION
Add dump functions for encoder/decoder.
For encoder & decoder dump be configured in media_codecs_intel_c2_video.xml.

Tracked-On: OAM-124732
Signed-off-by: Lina Sun <lina.sun@intel.com>