### PR TITLE
Workaround for timestamp not consistent

### DIFF
--- a/c2_components/src/mfx_c2_decoder_component.cpp
+++ b/c2_components/src/mfx_c2_decoder_component.cpp
@@ -2559,7 +2559,13 @@ void MfxC2DecoderComponent::WaitWork(MfxC2FrameOut&& frame_out, mfxSyncPoint syn
         std::lock_guard<std::mutex> lock(m_pendingWorksMutex);
 
         auto it = find_if(m_pendingWorks.begin(), m_pendingWorks.end(), [ready_timestamp] (const auto &item) {
-            return item.second->input.ordinal.timestamp == ready_timestamp;
+            uint64_t sub;
+            if (item.second->input.ordinal.timestamp.peeku() > ready_timestamp.peeku())
+                sub = item.second->input.ordinal.timestamp.peeku() - ready_timestamp.peeku();
+            else
+                sub = ready_timestamp.peeku() - item.second->input.ordinal.timestamp.peeku();
+            return sub < 3000;
+            // return item.second->input.ordinal.timestamp == ready_timestamp;
         });
 
         if (it != m_pendingWorks.end()) {


### PR DESCRIPTION
In widevine L3 stream play test, the timestamps between Load and Decode have gaps.

Tracked-On: OAM-124689