### PR TITLE
Fix AV1 encode issue

### DIFF
--- a/c2_components/src/mfx_c2_encoder_component.cpp
+++ b/c2_components/src/mfx_c2_encoder_component.cpp
@@ -83,7 +83,7 @@ C2R MfxC2EncoderComponent::AV1_ProfileLevelSetter(bool mayBlock, C2P<C2StreamPro
     if (!me.F(me.v.profile).supportsAtAll(me.v.profile))
         me.set().profile = PROFILE_AV1_0;
     if (!me.F(me.v.level).supportsAtAll(me.v.level))
-        me.set().level = LEVEL_AV1_7_3;
+        me.set().level = LEVEL_AV1_5_3;
 
     return C2R::Ok();
 }
@@ -316,7 +316,7 @@ MfxC2EncoderComponent::MfxC2EncoderComponent(const C2String name, const CreateCo
 
             addParameter(DefineParam(m_profileLevel, C2_PARAMKEY_PROFILE_LEVEL)
                 .withDefault(new C2StreamProfileLevelInfo::output(
-                    SINGLE_STREAM_ID, PROFILE_AV1_0, LEVEL_AV1_7_3))
+                    SINGLE_STREAM_ID, PROFILE_AV1_0, LEVEL_AV1_5_3))
                 .withFields({
                     C2F(m_profileLevel, C2ProfileLevelStruct::profile)
                         .oneOf({

--- a/c2_utils/src/mfx_defaults.cpp
+++ b/c2_utils/src/mfx_defaults.cpp
@@ -105,6 +105,9 @@ mfxStatus mfx_set_RateControlMethod(mfxU16 rate_control_method, mfxVideoParam* p
                 case MFX_CODEC_VP9:
                     params->mfx.TargetKbps = 3000;
                     break;
+                case MFX_CODEC_AV1:
+                    params->mfx.TargetKbps = 3000;
+                    break;
                 default:
                     MFX_DEBUG_TRACE_MSG("Unsupported Codec ID");
                     res = MFX_ERR_INVALID_VIDEO_PARAM;
@@ -212,6 +215,21 @@ mfxStatus mfx_set_defaults_mfxVideoParam_enc(mfxVideoParam* params)
             params->mfx.NumSlice = 1;
             params->mfx.NumRefFrame = 1;
             params->mfx.LowPower = MFX_CODINGOPTION_ON;
+            break;
+        case MFX_CODEC_AV1:
+	    res = mfx_set_RateControlMethod(MFX_RATECONTROL_CBR, params);
+            // If GopRefDist is not set, during Encoder Initialization, default
+            // value of 8 will be read from onevpl and used, which will cause problem.
+            // In framework during codec start, 4 works are queued to work queue, then
+            // codec will wait for work done notification to queue more works, while
+            // in mediasdk_c2, when handling the 4 works from framework, if GopRefDist
+            // is 8, the first 4 works will wait for future works to notify framework
+            // work done, so in framework codec will always be waiting for work done
+            // notification from mediasdk_c2, and mediasdk_c2 will always be waiting for
+            // more works from framework.
+            params->mfx.GopRefDist = 1;
+            params->mfx.GopPicSize = 16;
+            params->mfx.NumRefFrame = 1;
             break;
         default:
             break;


### PR DESCRIPTION
    [c2][encoder] Fix AV1 encoder issue

    Fix AV1 encode issue of "Encoder configure failed" and test be
    always waiting and can not run to end when running ffmpeg.

    "Encoder configure failed" is because in mfx_set_RateControlMethod
    function AV1 encoder case in not handled.

    Test always wait and can't run to end is because GopRefDist is not
    set when initializing AV1 encoder, default value of 8 from vpl is
    used, which caused mediasdk_c2 can't send work done notification
    to framework codec, so framework codec can't queue more works after
    queuing initial 4 works.

    Besides, use PROFILE_AV1_0 & LEVEL_AV1_5_3 as default AV1 encoder
    profile & level instead of PROFILE_AV1_0 & LEVEL_AV1_7_3, as the
    latter can not work.

    Tracked-On: OAM-124081
    Signed-off-by: Lina Sun <lina.sun@intel.com>