### PR TITLE
Fix playback 4k and 1080p video stuck issue

### DIFF
--- a/c2_components/src/mfx_c2_decoder_component.cpp
+++ b/c2_components/src/mfx_c2_decoder_component.cpp
@@ -1224,12 +1224,16 @@ mfxStatus MfxC2DecoderComponent::InitDecoder(std::shared_ptr<C2BlockPool> c2_all
             uint64_t usage, igbp_id;
             android::_UnwrapNativeCodec2GrallocMetadata(out_block->handle(), &width, &height, &format, &usage,
                                                         &stride, &generation, &igbp_id, &igbp_slot);
+// For android 15, it's using IGBA instead of BQ, we can not check if
+// surface is allocated by IGBA by igbp_id and igbp_slot
+#if PLATFORM_SDK_VERSION <= 34
             if ((!igbp_id && !igbp_slot) || (!igbp_id && igbp_slot == 0xffffffff))
             {
                 // No surface & BQ
                 m_mfxVideoParams.IOPattern = MFX_IOPATTERN_OUT_SYSTEM_MEMORY;
                 m_allocator = nullptr;
             }
+#endif
         }
     }
 


### PR DESCRIPTION
Issue is when playing 4k or 1080p video with gallery, video get stuck on android 15.

Cause is when c2 service change from hidl to aidl, block pool used in framework will change from buffer queue to IGBA, when allocating surface, surface metadata of igbp_id and igbp_slot will not be updated because they are buffer queue related concept. While in mediasdk_c2, it was checking igbp_id and igbp_slot during InitDecoder(), and caused IO pattern changed from video memory to system memory.

Solution is removing checking of igbp_id and igbp_slot for now. This way will cause some vts test fail, which will need be fixed.

Tracked-On: OAM-128397
Tracked-On: OAM-128324
Tracked-On: OAM-128315