### PR TITLE
Fix for VBR VP9 getting stuck

### DIFF
--- a/c2_components/src/mfx_c2_decoder_component.cpp
+++ b/c2_components/src/mfx_c2_decoder_component.cpp
@@ -1795,6 +1795,16 @@ mfxStatus MfxC2DecoderComponent::DecodeFrame(mfxBitstream *bs, MfxC2FrameOut&& f
                         ++m_uSyncedPointsCount;
                     }
                 }
+            } else {
+                ALOGE("Null surface_out after decode, notify all pending works");
+                {
+                    std::lock_guard<std::mutex> lock(m_pendingWorksMutex);
+                    auto it = m_pendingWorks.begin();
+                    while (it != m_pendingWorks.end()) {
+                            NotifyWorkDone(std::move(it->second), C2_NOT_FOUND);
+                            it = m_pendingWorks.erase(it);
+                    }
+                }
             }
         } else if (MFX_ERR_INCOMPATIBLE_VIDEO_PARAM == mfx_sts) {
             MFX_DEBUG_TRACE_MSG("MFX_ERR_INCOMPATIBLE_VIDEO_PARAM: resolution was changed");


### PR DESCRIPTION
Variable bitrate video gets stuck after playing for a few seconds.

For variable bitrate video, the DecodeFrameAsync frequently gives null value for surface_out. In such cases, the WaitWork is not called, and hence, the NotifyWorkDone doesn't get called.

Changes done:
- When surface_out is null, call NotifyWorkDone on all pending works.

Tests done:
- Play VBR and non-VBR video files, and ensure smooth playback.

Tracked-On: OAM-129739