### PR TITLE
Reset bitstream for re-append SPS/PPS header

### DIFF
--- a/c2_components/src/mfx_c2_decoder_component.cpp
+++ b/c2_components/src/mfx_c2_decoder_component.cpp
@@ -619,7 +619,7 @@ MfxC2DecoderComponent::MfxC2DecoderComponent(const C2String name, const CreateCo
         .withSetter(DefaultColorAspectsSetter)
         .build());
 
-    if (DECODER_VP9 != m_decoderType && DECODER_VP8 != m_decoderType) {
+    if (DECODER_VP8 != m_decoderType) {
         addParameter(
             DefineParam(m_inColorAspects, C2_PARAMKEY_VUI_COLOR_ASPECTS)
             .withDefault(new C2StreamColorAspectsInfo::input(
@@ -1456,6 +1456,11 @@ mfxStatus MfxC2DecoderComponent::HandleFormatChange()
         m_bInitialized = false;
         m_uMaxWidth = m_mfxVideoParams.mfx.FrameInfo.Width;
         m_uMaxHeight = m_mfxVideoParams.mfx.FrameInfo.Height;
+    }
+
+    if ((DECODER_H264 == m_decoderType || DECODER_H265 == m_decoderType) && m_c2Bitstream) {
+        MFX_DEBUG_TRACE_MSG("Reset BitStream for re-append header.");
+        m_c2Bitstream->Reset();
     }
 
     return mfx_res;
@@ -2935,7 +2940,7 @@ void MfxC2DecoderComponent::UpdateColorAspectsFromBitstream(const mfxExtVideoSig
 {
     MFX_DEBUG_TRACE_FUNC;
 
-    if (DECODER_VP9 == m_decoderType || DECODER_VP8 == m_decoderType) return;
+    if (DECODER_VP8 == m_decoderType) return;
 
     MFX_DEBUG_TRACE_I32(signalInfo.VideoFullRange);
     MFX_DEBUG_TRACE_I32(signalInfo.ColourPrimaries);


### PR DESCRIPTION
Enable dynamic ColorAspect and bit-depth changes
For H264 and H265 format,
1/ Use the same resolution event for ColorAspect and bit-depth
2/ Reset bitstream for re-appending SPS/PPS header once
   ColorAspect and bit-depth is changed
For VP9 and AV1
1/ Re-init VPL decoder once a new flag bitstream arrived
2/ setting ColorAspect also for VP9