### PR TITLE
Fixed a stuck issue when resolution changes

### DIFF
--- a/c2_components/src/mfx_c2_decoder_component.cpp
+++ b/c2_components/src/mfx_c2_decoder_component.cpp
@@ -2109,8 +2109,7 @@ void MfxC2DecoderComponent::DoWork(std::unique_ptr<C2Work>&& work)
     // Av1 and VP9 don't need the bs which flag is config.
     if (codecConfig && (DECODER_AV1 == m_decoderType || DECODER_VP9 == m_decoderType)) {
         FillEmptyWork(std::move(work), C2_OK);
-        // when seek during playback, no need to reinitialize decoder
-        if (true == m_bInitialized && !m_c2Bitstream->IsInReset()) {
+        if (true == m_bInitialized) {
             mfxStatus format_change_sts = HandleFormatChange();
             MFX_DEBUG_TRACE__mfxStatus(format_change_sts);
             mfx_sts = format_change_sts;

--- a/c2_components/src/mfx_c2_decoder_component.cpp
+++ b/c2_components/src/mfx_c2_decoder_component.cpp
@@ -44,6 +44,11 @@ constexpr c2_nsecs_t TIMEOUT_NS = MFX_SECOND_NS;
 constexpr uint64_t kMinInputBufferSize = 1 * WIDTH_1K * HEIGHT_1K;
 constexpr uint64_t kDefaultConsumerUsage =
     (GRALLOC_USAGE_HW_TEXTURE | GRALLOC_USAGE_HW_COMPOSER);
+// From Android 15, Buffer pool use IGBA instead of BufferQueue.
+// IGBA will strictly limit the number of buffers that can be allocated.
+// We added an extra buffer cache to prevent stucking when call
+// fetchGraphicBlock during resolution changes.
+constexpr uint32_t BufferPoolExtraCache = 1;
 
 // Android S declared VP8 profile
 #if PLATFORM_SDK_VERSION <= 30 // Android 11(R)
@@ -591,8 +596,8 @@ MfxC2DecoderComponent::MfxC2DecoderComponent(const C2String name, const CreateCo
     // form QueryIOSurf function call result.
     addParameter(
         DefineParam(m_actualOutputDelay, C2_PARAMKEY_OUTPUT_DELAY)
-        .withDefault(new C2PortActualDelayTuning::output(m_uOutputDelay))
-        .withFields({C2F(m_actualOutputDelay, value).inRange(0, m_uOutputDelay)})
+        .withDefault(new C2PortActualDelayTuning::output(m_uOutputDelay + BufferPoolExtraCache))
+        .withFields({C2F(m_actualOutputDelay, value).inRange(0, m_uOutputDelay + BufferPoolExtraCache)})
         .withSetter(Setter<decltype(*m_actualOutputDelay)>::StrictValueWithNoDeps)
         .build());
 


### PR DESCRIPTION
From Android 15, Buffer pool use IGBA instead of BufferQueue. IGBA will strictly limit the number of buffers that can be allocated. We added an extra buffer cache to prevent stucking when call fetchGraphicBlock during resolution changes.

Tracked-On: OAM-128843