### PR TITLE
Fix cts regression

### DIFF
--- a/c2_components/src/mfx_c2_decoder_component.cpp
+++ b/c2_components/src/mfx_c2_decoder_component.cpp
@@ -2192,7 +2192,7 @@ void MfxC2DecoderComponent::DoWork(std::unique_ptr<C2Work>&& work)
     bool encounterResolutionChanged = false;
     do {
         std::unique_ptr<C2ReadView> read_view;
-        res = m_c2Bitstream->AppendFrame(work->input, TIMEOUT_NS, &read_view, codecConfig | !m_bInitialized);
+        res = m_c2Bitstream->AppendFrame(work->input, TIMEOUT_NS, &read_view, codecConfig);
         if (C2_OK != res) break;
 
         {


### PR DESCRIPTION
Due to secure bitstreams lack FLAG_CODEC_CONFIG, new header is not saved.
This may cause problem of attaching the wrong header during RESET.
- Revert flag handling to avoid affecting normal decoders.

Tracked-On: OAM-130988