### PR TITLE
Rename data dump related properties per sepolicy requirement

### DIFF
--- a/c2_components/src/mfx_c2_decoder_component.cpp
+++ b/c2_components/src/mfx_c2_decoder_component.cpp
@@ -760,10 +760,10 @@ c2_status_t MfxC2DecoderComponent::Init()
 // 2. In adb shell, $setenforce 0
 // 3. In adb shell,
 //
-//    Case 1) For decoder input dump: $setprop c2.decoder.dump.input true
-//    Case 2) For decoder output dump: $setprop c2.decoder.dump.output.number 10
-//    Case 3) For encoder input dump: $setprop c2.encoder.dump.input.number 10
-//    Case 4) For encoder output dump: $setprop c2.encoder.dump.output true
+//    Case 1) For decoder input dump: $setprop vendor.c2.dump.decoder.input true
+//    Case 2) For decoder output dump: $setprop vendor.c2.dump.decoder.output.number 10
+//    Case 3) For encoder input dump: $setprop vendor.c2.dump.encoder.input.number 10
+//    Case 4) For encoder output dump: $setprop vendor.c2.dump.encoder.output true
 //
 //    yuv frames number to dump can be set as needed.
 //

--- a/c2_components/src/mfx_c2_encoder_component.cpp
+++ b/c2_components/src/mfx_c2_encoder_component.cpp
@@ -658,10 +658,10 @@ c2_status_t MfxC2EncoderComponent::Init()
 // 2. In adb shell, $setenforce 0
 // 3. In adb shell,
 //
-//    Case 1) For decoder input dump: $setprop c2.decoder.dump.input true
-//    Case 2) For decoder output dump: $setprop c2.decoder.dump.output.number 10
-//    Case 3) For encoder input dump: $setprop c2.encoder.dump.input.number 10
-//    Case 4) For encoder output dump: $setprop c2.encoder.dump.output true
+//    Case 1) For decoder input dump: $setprop vendor.c2.dump.decoder.input true
+//    Case 2) For decoder output dump: $setprop vendor.c2.dump.decoder.output.number 10
+//    Case 3) For encoder input dump: $setprop vendor.c2.dump.encoder.input.number 10
+//    Case 4) For encoder output dump: $setprop vendor.c2.dump.encoder.output true
 //
 //    yuv frames number to dump can be set as needed.
 //

--- a/c2_utils/include/mfx_c2_defs.h
+++ b/c2_utils/include/mfx_c2_defs.h
@@ -41,13 +41,13 @@
 #define MFX_C2_DUMP_INPUT_SUB_DIR "input"
 
 // dump when dump frames number > 0
-#define DECODER_DUMP_OUTPUT_KEY "c2.decoder.dump.output.number"
+#define DECODER_DUMP_OUTPUT_KEY "vendor.c2.dump.decoder.output.number"
 // dump when property set to true
-#define DECODER_DUMP_INPUT_KEY "c2.decoder.dump.input"
+#define DECODER_DUMP_INPUT_KEY "vendor.c2.dump.decoder.input"
 // dump when property set to true
-#define ENCODER_DUMP_OUTPUT_KEY "c2.encoder.dump.output"
+#define ENCODER_DUMP_OUTPUT_KEY "vendor.c2.dump.encoder.output"
 // dump when dump frames number > 0
-#define ENCODER_DUMP_INPUT_KEY "c2.encoder.dump.input.number"
+#define ENCODER_DUMP_INPUT_KEY "vendor.c2.dump.encoder.input.number"
 
 const c2_nsecs_t MFX_SECOND_NS = 1000000000; // 1e9
 


### PR DESCRIPTION
Because of no sepolicy for data dump related properties, lots of logs printed during codec, like: W libc : Access denied finding property "c2.decoder.dump.output.number".

So add sepolicy and rename data dump related properties per sepolicy requirement.

Tracked-On: OAM-131307